### PR TITLE
feat: refresh home ui with material design

### DIFF
--- a/nala/frontend/nalaLearnscape/package.json
+++ b/nala/frontend/nalaLearnscape/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mui/icons-material": "^5.16.7",
+    "@mui/material": "^5.16.7",
     "@tailwindcss/vite": "^4.1.13",
     "@xyflow/react": "^12.8.5",
     "classcat": "^5.0.5",
@@ -23,6 +25,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
+    "@emotion/react": "^11.13.3",
+    "@emotion/styled": "^11.13.0",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/nala/frontend/nalaLearnscape/src/App.css
+++ b/nala/frontend/nalaLearnscape/src/App.css
@@ -5,21 +5,14 @@
 }
 
 :root {
-  color: #14285b;
-  font-family: "Poppins", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background-color: #e8f1ff;
 }
 
 body {
   margin: 0;
-  background-color: #e8f1ff;
 }
 
 #root {
   min-height: 100vh;
   width: 100%;
-}
-
-a {
-  color: inherit;
 }

--- a/nala/frontend/nalaLearnscape/src/components/LearningStyleOverview.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/LearningStyleOverview.tsx
@@ -1,4 +1,11 @@
 import React, { useEffect, useMemo, useState } from "react";
+import {
+  Box,
+  Paper,
+  Stack,
+  Tooltip,
+  Typography,
+} from "@mui/material";
 
 type LearningSlice = {
   id: string;
@@ -87,24 +94,54 @@ const LearningStyleOverview: React.FC = () => {
   let cumulativeValue = 0;
 
   return (
-    <div className="learning-style-card">
-      <div className="learning-style-card__header">
-        <div className="learning-style-card__badge">
-          <span className="learning-style-card__badge-text">🔥</span>
-          <span className="learning-style-card__badge-number">25</span>
-        </div>
-        <h3>Current Learning Style:</h3>
-        <p className="learning-style-card__style">{currentStyle}</p>
-      </div>
-      <div className="learning-style-card__content">
-        <div className="learning-style-card__chart">
+    <Paper
+      elevation={0}
+      className="learning-style-card"
+      sx={{
+        borderRadius: { xs: 4, md: 5 },
+        px: { xs: 3, md: 4 },
+        py: { xs: 3, md: 4 },
+        background: "linear-gradient(180deg, #ffffff 0%, #f3f6ff 100%)",
+        boxShadow: "0 24px 50px rgba(76,115,255,0.18)",
+      }}
+    >
+      <Stack spacing={1.5} className="learning-style-card__header">
+        <Typography
+          variant="h6"
+          sx={{
+            color: "text.secondary",
+            letterSpacing: 0.5,
+          }}
+        >
+          Current Learning Style
+        </Typography>
+        <Typography
+          variant="h4"
+          className="learning-style-card__style"
+          sx={{
+            color: "primary.main",
+            fontSize: { xs: "1.6rem", md: "1.8rem" },
+          }}
+        >
+          {currentStyle}
+        </Typography>
+      </Stack>
+      <Stack
+        direction={{ xs: "column", md: "row" }}
+        spacing={{ xs: 3, md: 4 }}
+        alignItems="center"
+        className="learning-style-card__content"
+      >
+        <Box className="learning-style-card__chart">
           {hoveredSlice && (
-            <div className="learning-style-card__tooltip">
-              <strong>{hoveredSlice.label}</strong>
-              <span>
+            <Box className="learning-style-card__tooltip">
+              <Typography variant="subtitle1" fontWeight={700}>
+                {hoveredSlice.label}
+              </Typography>
+              <Typography variant="body2" color="primary.main">
                 {Math.round((hoveredSlice.value / total) * 100)}%
-              </span>
-            </div>
+              </Typography>
+            </Box>
           )}
           <svg viewBox="0 0 200 200" role="img" aria-label="Learning style distribution">
             <circle
@@ -142,37 +179,48 @@ const LearningStyleOverview: React.FC = () => {
               );
             })}
           </svg>
-        </div>
-        <div className="learning-style-card__legend">
+        </Box>
+        <Stack spacing={1.5} className="learning-style-card__legend">
           {data.map((slice) => (
-            <div className="learning-style-card__legend-item" key={slice.id}>
-              <span
+            <Stack
+              direction="row"
+              alignItems="center"
+              spacing={1.5}
+              key={slice.id}
+              className="learning-style-card__legend-item"
+            >
+              <Box
                 className="learning-style-card__legend-color"
-                style={{ backgroundColor: slice.color }}
+                sx={{ backgroundColor: slice.color }}
               />
-              <span className="learning-style-card__legend-label">{slice.label}</span>
-              <span className="learning-style-card__legend-value">
-                {Math.round((slice.value / total) * 100)}%
-              </span>
-              <span className="learning-style-card__info">
-                <span
+              <Box sx={{ flexGrow: 1 }}>
+                <Typography variant="subtitle1" className="learning-style-card__legend-label">
+                  {slice.label}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {Math.round((slice.value / total) * 100)}%
+                </Typography>
+              </Box>
+              <Tooltip
+                title={slice.description}
+                placement="top"
+                arrow
+                enterDelay={100}
+                leaveDelay={0}
+              >
+                <Box
                   className="learning-style-card__info-icon"
                   onMouseEnter={() => setHoveredSlice(slice)}
                   onMouseLeave={() => setHoveredSlice(null)}
                 >
                   ?
-                </span>
-                {hoveredSlice?.id === slice.id && (
-                  <div className="learning-style-card__info-tooltip">
-                    {slice.description}
-                  </div>
-                )}
-              </span>
-            </div>
+                </Box>
+              </Tooltip>
+            </Stack>
           ))}
-        </div>
-      </div>
-    </div>
+        </Stack>
+      </Stack>
+    </Paper>
   );
 };
 

--- a/nala/frontend/nalaLearnscape/src/components/Scheduler.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/Scheduler.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
+import { Box, Stack, Typography } from "@mui/material";
 import DragTimeBlock from "./DragTimeBlock";
 
 type ScheduleItem = {
@@ -118,14 +119,38 @@ const Scheduler: React.FC = () => {
   };
 
   return (
-    <div className="scheduler">
-      <div className="scheduler__header">
-        <h3>Recommended study plan for today:</h3>
-        <span className="scheduler__total">Total study time: {totalDurationLabel}</span>
-      </div>
-      <div className="scheduler__track-wrapper">
-        <div className="scheduler__time-label">0000</div>
-        <div
+    <Box className="scheduler" sx={{ backgroundColor: "rgba(255,255,255,0.18)", borderRadius: 4 }}>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        gap={1.5}
+        className="scheduler__header"
+      >
+        <Typography
+          variant="h6"
+          sx={{
+            fontFamily: '"Fredoka", sans-serif',
+            fontSize: { xs: "1.2rem", md: "1.35rem" },
+            color: "rgba(255,255,255,0.92)",
+          }}
+        >
+          Recommended study plan for today:
+        </Typography>
+        <Typography
+          variant="subtitle1"
+          className="scheduler__total"
+          sx={{
+            color: "rgba(255,255,255,0.85)",
+            fontWeight: 500,
+          }}
+        >
+          Total study time: {totalDurationLabel}
+        </Typography>
+      </Stack>
+      <Box className="scheduler__track-wrapper">
+        <Typography className="scheduler__time-label">0000</Typography>
+        <Box
           className="scheduler__track"
           ref={trackRef}
           onDragOver={handleDragOver}
@@ -170,12 +195,12 @@ const Scheduler: React.FC = () => {
               );
             })}
           </div>
-        </div>
-        <div className="scheduler__time-label scheduler__time-label--end">
+        </Box>
+        <Typography className="scheduler__time-label scheduler__time-label--end">
           2359
-        </div>
-      </div>
-    </div>
+        </Typography>
+      </Box>
+    </Box>
   );
 };
 

--- a/nala/frontend/nalaLearnscape/src/components/ThreadMapSection.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/ThreadMapSection.tsx
@@ -1,5 +1,15 @@
 import React, { useMemo, useState } from "react";
 import type { Edge, Node } from "@xyflow/react";
+import {
+  Box,
+  Button,
+  Menu,
+  MenuItem,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import FilterListRoundedIcon from "@mui/icons-material/FilterListRounded";
 import ThreadMap from "./ThreadMap";
 
 type ThreadMapOption = {
@@ -81,7 +91,7 @@ const THREAD_MAP_OPTIONS: ThreadMapOption[] = [
 
 const ThreadMapSection: React.FC = () => {
   const [selectedId, setSelectedId] = useState<string>(THREAD_MAP_OPTIONS[0].id);
-  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [filterAnchor, setFilterAnchor] = useState<null | HTMLElement>(null);
 
   const selectedOption = useMemo(
     () => THREAD_MAP_OPTIONS.find((option) => option.id === selectedId)!,
@@ -89,58 +99,107 @@ const ThreadMapSection: React.FC = () => {
   );
 
   return (
-    <section className="threadmap-section">
-      <header className="threadmap-section__header">
-        <div>
-          <h2>{selectedOption.label}</h2>
-          <p>{selectedOption.subtitle}</p>
-        </div>
-        <div className="threadmap-section__filter">
-          <button
-            type="button"
-            onClick={() => setIsFilterOpen((open) => !open)}
-            className="threadmap-section__filter-button"
-            aria-haspopup="listbox"
-            aria-expanded={isFilterOpen}
+    <Paper
+      elevation={0}
+      className="threadmap-section"
+      sx={{
+        borderRadius: 5,
+        px: { xs: 3, md: 4 },
+        py: { xs: 3, md: 4 },
+        backgroundColor: "#ffffff",
+        boxShadow: "0 22px 45px rgba(44,87,170,0.14)",
+      }}
+    >
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "flex-start", sm: "center" }}
+        spacing={{ xs: 2, sm: 3 }}
+        className="threadmap-section__header"
+      >
+        <Box>
+          <Typography
+            variant="h5"
+            sx={{
+              fontFamily: '"Fredoka", sans-serif',
+              color: "primary.main",
+              mb: 0.5,
+            }}
           >
-            <span className="threadmap-section__filter-icon">⛃</span>
+            {selectedOption.label}
+          </Typography>
+          <Typography variant="body1" color="text.secondary">
+            {selectedOption.subtitle}
+          </Typography>
+        </Box>
+        <div className="threadmap-section__filter">
+          <Button
+            variant="contained"
+            color="primary"
+            startIcon={<FilterListRoundedIcon />}
+            onClick={(event) => setFilterAnchor(event.currentTarget)}
+            className="threadmap-section__filter-button"
+            sx={{
+              borderRadius: 999,
+              px: 3,
+              background: "linear-gradient(135deg, #4C73FF 0%, #7EA8FF 100%)",
+              boxShadow: "0 12px 25px rgba(76,115,255,0.25)",
+            }}
+          >
             Filter
-          </button>
-          {isFilterOpen && (
-            <ul className="threadmap-section__filter-menu" role="listbox">
-              {THREAD_MAP_OPTIONS.map((option) => (
-                <li key={option.id}>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setSelectedId(option.id);
-                      setIsFilterOpen(false);
-                    }}
-                    className={
-                      option.id === selectedId
-                        ? "threadmap-section__filter-option threadmap-section__filter-option--active"
-                        : "threadmap-section__filter-option"
-                    }
-                    role="option"
-                    aria-selected={option.id === selectedId}
-                  >
-                    <span className="threadmap-section__filter-option-label">
-                      {option.label}
-                    </span>
-                    <span className="threadmap-section__filter-option-subtitle">
-                      {option.subtitle}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
+          </Button>
+          <Menu
+            anchorEl={filterAnchor}
+            open={Boolean(filterAnchor)}
+            onClose={() => setFilterAnchor(null)}
+            MenuListProps={{ "aria-label": "Filter thread map" }}
+            PaperProps={{
+              sx: {
+                borderRadius: 3,
+                minWidth: 240,
+                p: 1,
+              },
+            }}
+          >
+            {THREAD_MAP_OPTIONS.map((option) => (
+              <MenuItem
+                key={option.id}
+                selected={option.id === selectedId}
+                onClick={() => {
+                  setSelectedId(option.id);
+                  setFilterAnchor(null);
+                }}
+                sx={{
+                  borderRadius: 2,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "flex-start",
+                  gap: 0.5,
+                  py: 1.5,
+                }}
+              >
+                <Typography
+                  variant="subtitle1"
+                  sx={{
+                    fontWeight: 600,
+                    color: option.id === selectedId ? "primary.main" : "text.primary",
+                    fontFamily: '"Fredoka", sans-serif',
+                  }}
+                >
+                  {option.label}
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {option.subtitle}
+                </Typography>
+              </MenuItem>
+            ))}
+          </Menu>
         </div>
-      </header>
-      <div className="threadmap-section__body">
+      </Stack>
+      <Box className="threadmap-section__body">
         <ThreadMap nodes={selectedOption.nodes} edges={selectedOption.edges} />
-      </div>
-    </section>
+      </Box>
+    </Paper>
   );
 };
 

--- a/nala/frontend/nalaLearnscape/src/components/welcome.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/welcome.tsx
@@ -1,58 +1,238 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Divider,
+  Drawer,
+  IconButton,
+  Link,
+  List,
+  ListItemButton,
+  ListItemText,
+  Paper,
+  Stack,
+  Typography,
+} from "@mui/material";
+import MenuRoundedIcon from "@mui/icons-material/MenuRounded";
+import LocalFireDepartmentRoundedIcon from "@mui/icons-material/LocalFireDepartmentRounded";
+import { useLocation, useNavigate } from "react-router-dom";
 import Scheduler from "./Scheduler";
 import LearningStyleOverview from "./LearningStyleOverview";
 
 const Welcome: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  const navigationItems = useMemo(
+    () => [
+      { label: "Home", path: "/" },
+      { label: "Course", path: "/threadmap" },
+    ],
+    []
+  );
+
+  const handleNavigate = (path: string): void => {
+    navigate(path);
+    setIsDrawerOpen(false);
+  };
 
   return (
-    <section className="welcome">
-      <div className="welcome__card">
-        <div className="welcome__header">
-          <button className="welcome__menu" aria-label="Open navigation menu">
-            <span />
-            <span />
-            <span />
-          </button>
-          <div className="welcome__title-group">
-            <h1>
-              Welcome back,
-              <span className="welcome__highlight"> John!</span>
-            </h1>
-            <button
-              type="button"
-              className="welcome__cta"
-              onClick={() => setIsModalOpen(true)}
+    <Box
+      component="section"
+      className="welcome"
+      sx={{
+        display: "grid",
+        gridTemplateColumns: { xs: "1fr", lg: "minmax(0, 1.9fr) minmax(0, 1fr)" },
+        gap: { xs: 3, lg: 3 },
+        alignItems: "stretch",
+      }}
+    >
+      <Paper
+        elevation={0}
+        className="welcome__card"
+        sx={{
+          position: "relative",
+          borderRadius: { xs: 5, md: 6 },
+          px: { xs: 3, md: 5 },
+          py: { xs: 3, md: 4 },
+          background:
+            "linear-gradient(135deg, rgba(76,115,255,0.96) 0%, rgba(110,162,255,0.9) 60%, rgba(147,193,255,0.95) 100%)",
+          color: "#FFFFFF",
+          boxShadow: "0 24px 60px rgba(44,87,170,0.28)",
+          overflow: "hidden",
+        }}
+      >
+        <Stack
+          direction="row"
+          spacing={2}
+          alignItems="flex-start"
+          justifyContent="space-between"
+          className="welcome__header"
+        >
+          <Stack direction="row" spacing={2} alignItems="flex-start">
+            <IconButton
+              className="welcome__menu"
+              onClick={() => setIsDrawerOpen(true)}
+              sx={{
+                borderRadius: 3,
+                backgroundColor: "rgba(255,255,255,0.18)",
+                color: "inherit",
+                border: "1px solid rgba(255,255,255,0.36)",
+                p: 1,
+                "&:hover": {
+                  backgroundColor: "rgba(255,255,255,0.28)",
+                },
+              }}
+              aria-label="Open navigation menu"
             >
-              Find out why
-            </button>
-          </div>
-        </div>
+              <MenuRoundedIcon />
+            </IconButton>
+            <Box className="welcome__title-group">
+              <Typography
+                variant="h3"
+                sx={{
+                  mb: 1,
+                  color: "#FFFFFF",
+                  fontSize: { xs: "1.9rem", md: "2.3rem" },
+                  lineHeight: 1.05,
+                }}
+              >
+                Welcome back,
+                <Box component="span" className="welcome__highlight" sx={{ color: "#FFE08C" }}>
+                  {" "}John!
+                </Box>
+              </Typography>
+              <Link
+                component="button"
+                type="button"
+                onClick={() => setIsModalOpen(true)}
+                underline="hover"
+                className="welcome__cta"
+                sx={{
+                  color: "#FFFFFF",
+                  fontWeight: 600,
+                  fontSize: "1rem",
+                  letterSpacing: 0.3,
+                  "&:hover": { color: "#FFE08C" },
+                }}
+              >
+                Find out why
+              </Link>
+            </Box>
+          </Stack>
+          <Stack
+            direction="column"
+            alignItems="center"
+            spacing={0.5}
+            sx={{
+              backgroundColor: "rgba(255,255,255,0.18)",
+              borderRadius: 4,
+              px: 2,
+              py: 1.5,
+              border: "1px solid rgba(255,255,255,0.35)",
+              minWidth: 72,
+            }}
+          >
+            <LocalFireDepartmentRoundedIcon fontSize="large" sx={{ color: "#FFE08C" }} />
+            <Typography variant="subtitle2" sx={{ fontWeight: 700, letterSpacing: 1 }}>
+              25 Days
+            </Typography>
+            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.85)" }}>
+              Streak
+            </Typography>
+          </Stack>
+        </Stack>
+
+        <Divider
+          sx={{
+            my: { xs: 2.5, md: 3 },
+            borderColor: "rgba(255,255,255,0.28)",
+            borderBottomWidth: 1,
+          }}
+        />
+
         <Scheduler />
-      </div>
+      </Paper>
+
       <LearningStyleOverview />
 
-      {isModalOpen && (
-        <div className="welcome__modal" role="dialog" aria-modal="true">
-          <div className="welcome__modal-content">
-            <button
-              type="button"
-              className="welcome__modal-close"
-              onClick={() => setIsModalOpen(false)}
-              aria-label="Close explanation"
+      <Drawer
+        anchor="left"
+        open={isDrawerOpen}
+        onClose={() => setIsDrawerOpen(false)}
+        PaperProps={{
+          sx: {
+            width: 260,
+            backgroundColor: "#f4f7ff",
+            paddingY: 3,
+            borderTopRightRadius: 24,
+            borderBottomRightRadius: 24,
+          },
+        }}
+      >
+        <Typography variant="h6" sx={{ px: 3, pb: 2, color: "#1A2C5E" }}>
+          Quick Links
+        </Typography>
+        <List>
+          {navigationItems.map((item) => (
+            <ListItemButton
+              key={item.path}
+              onClick={() => handleNavigate(item.path)}
+              selected={location.pathname === item.path}
+              sx={{
+                mx: 2,
+                mb: 1,
+                borderRadius: 3,
+                boxShadow: location.pathname === item.path ? "0 8px 18px rgba(76,115,255,0.2)" : "none",
+                backgroundColor:
+                  location.pathname === item.path ? "rgba(76,115,255,0.12)" : "transparent",
+              }}
             >
-              ×
-            </button>
-            <div className="welcome__modal-body" />
-          </div>
-          <div
-            className="welcome__modal-backdrop"
-            onClick={() => setIsModalOpen(false)}
-            aria-hidden="true"
-          />
-        </div>
-      )}
-    </section>
+              <ListItemText
+                primary={item.label}
+                primaryTypographyProps={{
+                  fontFamily: '"Fredoka", sans-serif',
+                  fontWeight: 600,
+                  sx: {
+                    color:
+                      location.pathname === item.path
+                        ? "primary.main"
+                        : "text.primary",
+                  },
+                }}
+              />
+            </ListItemButton>
+          ))}
+        </List>
+      </Drawer>
+
+      <Dialog open={isModalOpen} onClose={() => setIsModalOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle
+          sx={{
+            fontFamily: '"Fredoka", sans-serif',
+            fontWeight: 600,
+            color: "primary.main",
+          }}
+        >
+          Why this plan works
+        </DialogTitle>
+        <DialogContent sx={{ minHeight: 180 }}>
+          <Typography variant="body1" color="text.secondary">
+            Additional insights will appear here once the recommendation engine is connected.
+          </Typography>
+          <Box mt={3}>
+            <Button variant="contained" onClick={() => setIsModalOpen(false)}>
+              Got it
+            </Button>
+          </Box>
+        </DialogContent>
+      </Dialog>
+    </Box>
   );
 };
 

--- a/nala/frontend/nalaLearnscape/src/fonts.css
+++ b/nala/frontend/nalaLearnscape/src/fonts.css
@@ -1,15 +1,36 @@
-    /* src/fonts.css */
-    @font-face {
-      font-family: "GlacialIndifference-Bold"; /* Choose a descriptive name */
-      src: local("GlacialIndifference-Bold"), url("./fonts/GlacialIndifference-Bold.otf") format("opentype");
-      font-weight: bold; /* Or specify the weight if applicable (e.g., bold, 500) */
-      font-style: normal; /* Or specify if italic */
-    }
+@font-face {
+  font-family: "GlacialIndifference";
+  src: local("GlacialIndifference"),
+    url("./fonts/GlacialIndifference-Bold.otf") format("opentype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
 
-    @font-face {
-      font-family: "Fredoka-Bold"; /* Choose a descriptive name */
-      src: local("Fredoka-Bold"), url("./fonts/Fredoka-VariableFont_wdth\,wght.ttf") format("truetype");
-      font-weight: bold; /* Or specify the weight if applicable (e.g., bold, 500) */
-      font-style: normal; /* Or specify if italic */
-    }
+@font-face {
+  font-family: "GlacialIndifference";
+  src: local("GlacialIndifference"),
+    url("./fonts/GlacialIndifference-Bold.otf") format("opentype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Fredoka";
+  src: local("Fredoka"),
+    url("./fonts/Fredoka-VariableFont_wdth,wght.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Fredoka";
+  src: local("Fredoka"),
+    url("./fonts/Fredoka-VariableFont_wdth,wght.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
     

--- a/nala/frontend/nalaLearnscape/src/main.tsx
+++ b/nala/frontend/nalaLearnscape/src/main.tsx
@@ -1,13 +1,40 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
-import { ReactFlowProvider } from '@xyflow/react'
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { CssBaseline, GlobalStyles, ThemeProvider } from "@mui/material";
+import "./index.css";
+import "./fonts.css";
+import App from "./App.tsx";
+import { ReactFlowProvider } from "@xyflow/react";
+import theme from "./theme";
 
-createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ReactFlowProvider>
-      <App />
-    </ReactFlowProvider>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <GlobalStyles
+        styles={{
+          body: {
+            backgroundColor: theme.palette.background.default,
+            fontFamily: theme.typography.fontFamily,
+            color: theme.palette.text.primary,
+          },
+          h1: {
+            fontFamily: theme.typography.h1.fontFamily,
+          },
+          h2: {
+            fontFamily: theme.typography.h2.fontFamily,
+          },
+          h3: {
+            fontFamily: theme.typography.h3.fontFamily,
+          },
+          a: {
+            color: "inherit",
+          },
+        }}
+      />
+      <ReactFlowProvider>
+        <App />
+      </ReactFlowProvider>
+    </ThemeProvider>
   </StrictMode>
-)
+);

--- a/nala/frontend/nalaLearnscape/src/pages/Home.css
+++ b/nala/frontend/nalaLearnscape/src/pages/Home.css
@@ -1,190 +1,115 @@
 .home {
-  padding: 32px 48px;
-  display: flex;
-  flex-direction: column;
-  gap: 32px;
   background: #e8f1ff;
-  box-sizing: border-box;
 }
 
 .home__below {
-  display: grid;
-  grid-template-columns: minmax(0, 2.2fr) minmax(0, 0.8fr);
-  gap: 24px;
+  width: 100%;
 }
 
 .home__side-card {
-  background: linear-gradient(180deg, #d8e5ff 0%, #f1f5ff 100%);
   border-radius: 32px;
-  box-shadow: 0 12px 32px rgba(33, 77, 156, 0.15);
-  min-height: 260px;
 }
 
 .welcome {
-  display: grid;
-  grid-template-columns: minmax(0, 1.9fr) minmax(0, 1fr);
-  gap: 24px;
+  width: 100%;
 }
 
 .welcome__card {
-  background: linear-gradient(135deg, #4c73ff 0%, #6fa2ff 100%);
-  border-radius: 32px;
-  padding: 32px;
-  color: #ffffff;
-  position: relative;
-  box-shadow: 0 24px 64px rgba(44, 87, 170, 0.35);
-  min-height: 340px;
   display: flex;
   flex-direction: column;
   gap: 24px;
+  min-height: 340px;
+  position: relative;
 }
 
 .welcome__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 16px;
-}
-
-.welcome__menu {
-  background: rgba(255, 255, 255, 0.15);
-  border: none;
-  border-radius: 12px;
-  padding: 10px 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  cursor: pointer;
-}
-
-.welcome__menu span {
-  display: block;
-  width: 18px;
-  height: 2px;
-  background: #ffffff;
-  border-radius: 999px;
-}
-
-.welcome__title-group h1 {
-  margin: 0;
-  font-size: 2.2rem;
-  line-height: 1.1;
+  width: 100%;
 }
 
 .welcome__highlight {
-  display: inline-block;
-  margin-left: 6px;
+  color: #ffe08c;
 }
 
 .welcome__cta {
-  margin-top: 12px;
-  background: rgba(255, 255, 255, 0.2);
-  border: 1px solid rgba(255, 255, 255, 0.45);
-  color: #ffffff;
-  border-radius: 999px;
-  padding: 8px 16px;
-  cursor: pointer;
+  font-family: "Fredoka", "GlacialIndifference", sans-serif;
   font-weight: 600;
-  text-decoration: none;
-}
-
-.welcome__cta:hover,
-.welcome__cta:focus {
-  background: rgba(255, 255, 255, 0.3);
 }
 
 .scheduler {
-  background: rgba(255, 255, 255, 0.15);
-  border-radius: 28px;
-  padding: 20px;
+  padding: 24px;
+  border-radius: 32px;
+  backdrop-filter: blur(6px);
   display: flex;
   flex-direction: column;
   gap: 18px;
 }
 
-.scheduler__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-}
-
-.scheduler__header h3 {
-  margin: 0;
-  font-size: 1.1rem;
-}
-
-.scheduler__total {
-  font-size: 0.95rem;
-  opacity: 0.85;
-}
-
 .scheduler__track-wrapper {
   display: grid;
-  grid-template-columns: 60px minmax(0, 1fr) 60px;
-  gap: 12px;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
+  gap: 18px;
 }
 
 .scheduler__time-label {
+  font-family: "Fredoka", sans-serif;
   font-weight: 600;
-}
-
-.scheduler__time-label--end {
-  text-align: right;
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .scheduler__track {
   position: relative;
-  background: rgba(255, 255, 255, 0.2);
-  border-radius: 18px;
   height: 140px;
+  border-radius: 30px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.22);
   overflow: hidden;
+  padding: 20px 0;
 }
 
 .scheduler__markers {
   position: absolute;
-  inset: 12px 12px 36px 12px;
+  inset: 0;
   pointer-events: none;
-  z-index: 1;
 }
 
 .scheduler__marker {
   position: absolute;
-  top: 0;
+  top: 14px;
+  bottom: 14px;
   transform: translateX(-50%);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
 }
 
 .scheduler__marker-line {
-  display: block;
   width: 2px;
-  height: 70px;
-  background: rgba(255, 255, 255, 0.35);
+  flex: 1;
+  background: rgba(255, 255, 255, 0.28);
 }
 
 .scheduler__marker-label {
   font-size: 0.75rem;
-  opacity: 0.8;
+  font-family: "GlacialIndifference", sans-serif;
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .scheduler__block {
   position: absolute;
-  top: 36px;
-  height: 64px;
-  border-radius: 18px;
-  padding: 12px 16px;
-  box-sizing: border-box;
-  color: #0c1e4a;
+  top: 28px;
+  bottom: 28px;
+  border-radius: 24px;
+  border: 1px solid transparent;
+  padding: 18px 20px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  box-shadow: 0 16px 28px rgba(0, 0, 0, 0.18);
+  color: #0c1e4a;
   cursor: grab;
-  box-shadow: 0 12px 24px rgba(18, 39, 95, 0.2);
-  z-index: 2;
 }
 
 .scheduler__block:active {
@@ -194,6 +119,7 @@
 .drag-time-block__label {
   font-weight: 600;
   font-size: 0.95rem;
+  font-family: "GlacialIndifference", sans-serif;
 }
 
 .drag-time-block__duration {
@@ -202,10 +128,6 @@
 }
 
 .learning-style-card {
-  background: #ffffff;
-  border-radius: 32px;
-  padding: 28px;
-  box-shadow: 0 24px 64px rgba(44, 87, 170, 0.18);
   display: flex;
   flex-direction: column;
   gap: 18px;
@@ -214,43 +136,15 @@
 .learning-style-card__header {
   display: flex;
   flex-direction: column;
-  gap: 8px;
-}
-
-.learning-style-card__badge {
-  align-self: flex-end;
-  background: #1b46d1;
-  border-radius: 50%;
-  width: 64px;
-  height: 64px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  color: #ffffff;
-  font-weight: 700;
-  box-shadow: 0 12px 28px rgba(27, 70, 209, 0.35);
-}
-
-.learning-style-card__badge-text {
-  font-size: 1.4rem;
-}
-
-.learning-style-card__badge-number {
-  font-size: 1rem;
+  gap: 6px;
 }
 
 .learning-style-card__style {
-  margin: 0;
-  font-size: 1.4rem;
-  color: #1b46d1;
-  font-weight: 700;
+  font-family: "Fredoka", sans-serif;
 }
 
 .learning-style-card__content {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
-  gap: 20px;
+  width: 100%;
 }
 
 .learning-style-card__chart {
@@ -262,275 +156,74 @@
 
 .learning-style-card__tooltip {
   position: absolute;
-  top: -18px;
-  background: #1b46d1;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(76, 115, 255, 0.92);
   color: #ffffff;
-  padding: 8px 12px;
-  border-radius: 12px;
-  font-size: 0.85rem;
+  padding: 8px 14px;
+  border-radius: 16px;
   display: flex;
   flex-direction: column;
   align-items: center;
   gap: 4px;
-  box-shadow: 0 12px 24px rgba(27, 70, 209, 0.2);
+  font-family: "GlacialIndifference", sans-serif;
+  pointer-events: none;
 }
 
 .learning-style-card__legend {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+  width: 100%;
 }
 
 .learning-style-card__legend-item {
-  display: grid;
-  grid-template-columns: auto 1fr auto auto;
-  gap: 12px;
-  align-items: center;
-  position: relative;
+  border-radius: 18px;
+  padding: 12px 16px;
+  background: rgba(232, 241, 255, 0.5);
 }
 
 .learning-style-card__legend-color {
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
   border-radius: 50%;
-}
-
-.learning-style-card__legend-label {
-  font-weight: 600;
-}
-
-.learning-style-card__legend-value {
-  font-weight: 600;
-  color: #1b46d1;
-}
-
-.learning-style-card__info {
-  position: relative;
 }
 
 .learning-style-card__info-icon {
-  width: 20px;
-  height: 20px;
+  width: 26px;
+  height: 26px;
   border-radius: 50%;
   background: #e1e9ff;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  font-weight: 700;
-  cursor: default;
   color: #1b46d1;
-}
-
-.learning-style-card__info-tooltip {
-  position: absolute;
-  bottom: calc(100% + 10px);
-  left: 50%;
-  transform: translateX(-50%);
-  background: #1b46d1;
-  color: #ffffff;
-  padding: 8px 12px;
-  border-radius: 12px;
-  width: 200px;
-  font-size: 0.75rem;
-  line-height: 1.2;
-  box-shadow: 0 12px 24px rgba(27, 70, 209, 0.2);
-  z-index: 5;
-}
-
-.learning-style-card__info-tooltip::after {
-  content: "";
-  position: absolute;
-  bottom: -6px;
-  left: 50%;
-  transform: translateX(-50%);
-  border-width: 6px;
-  border-style: solid;
-  border-color: #1b46d1 transparent transparent transparent;
-}
-
-.welcome__modal {
-  position: fixed;
-  inset: 0;
-  display: flex;
-  justify-content: center;
+  font-weight: 700;
+  display: inline-flex;
   align-items: center;
-  z-index: 1000;
-}
-
-.welcome__modal-backdrop {
-  position: absolute;
-  inset: 0;
-  background: rgba(8, 18, 46, 0.4);
-}
-
-.welcome__modal-content {
-  position: relative;
-  background: #ffffff;
-  border-radius: 24px;
-  padding: 32px;
-  width: min(480px, 90%);
-  min-height: 240px;
-  box-shadow: 0 24px 64px rgba(17, 32, 70, 0.3);
-  z-index: 1001;
-}
-
-.welcome__modal-close {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  border: none;
-  background: transparent;
-  font-size: 1.5rem;
-  cursor: pointer;
+  justify-content: center;
+  font-family: "Fredoka", sans-serif;
+  cursor: default;
 }
 
 .threadmap-section {
-  background: #ffffff;
-  border-radius: 32px;
-  padding: 24px 28px;
-  box-shadow: 0 24px 64px rgba(44, 87, 170, 0.18);
   display: flex;
   flex-direction: column;
-  gap: 18px;
-}
-
-.threadmap-section__header {
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-}
-
-.threadmap-section__header h2 {
-  margin: 0;
-  font-size: 1.4rem;
-  color: #1b46d1;
-}
-
-.threadmap-section__header p {
-  margin: 4px 0 0;
-  color: #4d5f8f;
-}
-
-.threadmap-section__filter {
-  position: relative;
-}
-
-.threadmap-section__filter-button {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 16px;
-  background: #e1e9ff;
-  border-radius: 999px;
-  border: 1px solid #b3c6ff;
-  cursor: pointer;
-  font-weight: 600;
-  color: #1b46d1;
-}
-
-.threadmap-section__filter-icon {
-  font-size: 1.1rem;
-}
-
-.threadmap-section__filter-menu {
-  position: absolute;
-  right: 0;
-  margin-top: 12px;
-  background: #ffffff;
-  border-radius: 20px;
-  box-shadow: 0 18px 48px rgba(27, 70, 209, 0.2);
-  padding: 12px;
-  list-style: none;
-  min-width: 240px;
-  z-index: 10;
-}
-
-.threadmap-section__filter-option {
-  width: 100%;
-  border: none;
-  background: transparent;
-  text-align: left;
-  padding: 12px 16px;
-  border-radius: 16px;
-  cursor: pointer;
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  color: #1b46d1;
-}
-
-.threadmap-section__filter-option:hover,
-.threadmap-section__filter-option:focus {
-  background: #e8f1ff;
-}
-
-.threadmap-section__filter-option--active {
-  background: linear-gradient(135deg, #4c73ff 0%, #6fa2ff 100%);
-  color: #ffffff;
-}
-
-.threadmap-section__filter-option-label {
-  font-weight: 600;
-}
-
-.threadmap-section__filter-option-subtitle {
-  font-size: 0.8rem;
-  opacity: 0.85;
+  gap: 16px;
 }
 
 .threadmap-section__body {
-  background: #f4f7ff;
-  border-radius: 24px;
+  border-radius: 28px;
+  background: #f5f8ff;
   padding: 12px;
-  height: 320px;
 }
 
-.threadmap,
-.threadmap-page .react-flow__renderer {
-  background: transparent !important;
-  border-radius: 20px;
-}
-
-.threadmap-page {
-  height: 100vh;
-  padding: 24px;
-  box-sizing: border-box;
-}
-
-.threadmap-page .react-flow {
-  background: #f4f7ff;
-  border-radius: 24px;
-}
-
-@media (max-width: 1200px) {
+@media (max-width: 1024px) {
   .welcome {
     grid-template-columns: 1fr;
   }
 
-  .home__below {
-    grid-template-columns: 1fr;
-  }
-}
-
-@media (max-width: 768px) {
-  .home {
-    padding: 24px;
-  }
-
-  .welcome__card {
-    padding: 24px;
-  }
-
-  .learning-style-card__content {
-    grid-template-columns: 1fr;
-  }
-
   .scheduler__track-wrapper {
-    grid-template-columns: auto 1fr auto;
+    grid-template-columns: auto 1fr;
+    grid-template-rows: auto auto;
   }
 
-  .scheduler__track {
-    height: 120px;
+  .scheduler__time-label--end {
+    justify-self: end;
   }
 }

--- a/nala/frontend/nalaLearnscape/src/pages/Home.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/Home.tsx
@@ -1,17 +1,53 @@
 import React from "react";
+import { Box, Container, Paper, Stack, Typography } from "@mui/material";
+import Grid from "@mui/material/Grid";
 import Welcome from "../components/welcome";
 import ThreadMapSection from "../components/ThreadMapSection";
 import "./Home.css";
 
 const Home: React.FC = () => {
   return (
-    <main className="home">
-      <Welcome />
-      <div className="home__below">
-        <ThreadMapSection />
-        <aside className="home__side-card" aria-hidden="true" />
-      </div>
-    </main>
+    <Box component="main" sx={{ py: { xs: 4, md: 6 } }} className="home">
+      <Container maxWidth="lg" disableGutters sx={{ px: { xs: 3, md: 5 } }}>
+        <Stack spacing={{ xs: 4, md: 5 }}>
+          <Welcome />
+          <Grid container spacing={3} className="home__below">
+            <Grid item xs={12} md={8}>
+              <ThreadMapSection />
+            </Grid>
+            <Grid item xs={12} md={4}>
+              <Paper
+                elevation={0}
+                className="home__side-card"
+                sx={{
+                  minHeight: { xs: 200, md: 300 },
+                  borderRadius: 5,
+                  px: { xs: 3, md: 4 },
+                  py: { xs: 3, md: 4 },
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  background:
+                    "linear-gradient(180deg, rgba(216,229,255,0.85) 0%, rgba(241,245,255,0.9) 100%)",
+                  boxShadow: "inset 0 0 0 1px rgba(76,115,255,0.1)",
+                }}
+              >
+                <Typography
+                  variant="body1"
+                  color="text.secondary"
+                  sx={{
+                    textAlign: "center",
+                    fontFamily: '"GlacialIndifference", sans-serif',
+                  }}
+                >
+                  Personal insights and streak milestones will appear here soon.
+                </Typography>
+              </Paper>
+            </Grid>
+          </Grid>
+        </Stack>
+      </Container>
+    </Box>
   );
 };
 

--- a/nala/frontend/nalaLearnscape/src/theme.ts
+++ b/nala/frontend/nalaLearnscape/src/theme.ts
@@ -1,0 +1,45 @@
+import { createTheme } from "@mui/material/styles";
+
+const theme = createTheme({
+  palette: {
+    background: {
+      default: "#E8F1FF",
+    },
+    primary: {
+      main: "#4C73FF",
+      light: "#7EA8FF",
+      dark: "#2B4BC7",
+    },
+    secondary: {
+      main: "#FFB347",
+    },
+    text: {
+      primary: "#1A2C5E",
+      secondary: "#4C73FF",
+    },
+  },
+  shape: {
+    borderRadius: 24,
+  },
+  typography: {
+    fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    h1: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    h2: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    h3: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    button: {
+      textTransform: "none",
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    },
+  },
+});
+
+export default theme;


### PR DESCRIPTION
## Summary
- integrate Material UI theme support with Fredoka and Glacial Indifference typography across the app
- rebuild the home welcome layout with Material UI cards, navigation drawer, scheduler, and learning style overview that mirror the provided reference
- refresh the thread map section and supporting styles to align with the new visual system

## Testing
- npm run lint *(fails: missing npm dependencies in the sandbox registry)*
- npm run build *(fails: missing npm dependencies in the sandbox registry)*

------
https://chatgpt.com/codex/tasks/task_e_68d56ddecdf883329ee291a1661d32e4