### PR TITLE
Align home dashboard UI with reference design

### DIFF
--- a/nala/frontend/nalaLearnscape/src/components/LearningStyleOverview.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/LearningStyleOverview.tsx
@@ -103,20 +103,23 @@ const LearningStyleOverview: React.FC = () => {
         py: { xs: 3, md: 4 },
         background: "linear-gradient(180deg, #ffffff 0%, #f3f6ff 100%)",
         boxShadow: "0 24px 50px rgba(76,115,255,0.18)",
+        border: "1px solid rgba(76,115,255,0.14)",
       }}
     >
       <Stack spacing={1.5} className="learning-style-card__header">
         <Typography
-          variant="h6"
+          variant="subtitle2"
           sx={{
-            color: "text.secondary",
-            letterSpacing: 0.5,
+            color: "#4C73FF",
+            letterSpacing: 1,
+            textTransform: "uppercase",
+            fontWeight: 700,
           }}
         >
           Current Learning Style
         </Typography>
         <Typography
-          variant="h4"
+          variant="h3"
           className="learning-style-card__style"
           sx={{
             color: "primary.main",
@@ -126,12 +129,12 @@ const LearningStyleOverview: React.FC = () => {
           {currentStyle}
         </Typography>
       </Stack>
-      <Stack
-        direction={{ xs: "column", md: "row" }}
-        spacing={{ xs: 3, md: 4 }}
-        alignItems="center"
-        className="learning-style-card__content"
-      >
+        <Stack
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 3, md: 4 }}
+          alignItems="center"
+          className="learning-style-card__content"
+        >
         <Box className="learning-style-card__chart">
           {hoveredSlice && (
             <Box className="learning-style-card__tooltip">
@@ -207,6 +210,21 @@ const LearningStyleOverview: React.FC = () => {
                 arrow
                 enterDelay={100}
                 leaveDelay={0}
+                slotProps={{
+                  tooltip: {
+                    sx: {
+                      backgroundColor: "rgba(40,72,209,0.95)",
+                      borderRadius: 2,
+                      fontFamily: '"GlacialIndifference", sans-serif',
+                      fontSize: "0.75rem",
+                      px: 1.5,
+                      py: 1,
+                    },
+                  },
+                  arrow: {
+                    sx: { color: "rgba(40,72,209,0.95)" },
+                  },
+                }}
               >
                 <Box
                   className="learning-style-card__info-icon"

--- a/nala/frontend/nalaLearnscape/src/components/Scheduler.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/Scheduler.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo, useRef, useState } from "react";
+import type { ReactNode } from "react";
 import { Box, Stack, Typography } from "@mui/material";
 import DragTimeBlock from "./DragTimeBlock";
 
@@ -17,6 +18,10 @@ const clamp = (value: number, min: number, max: number): number => {
   if (value > max) return max;
   return value;
 };
+
+export interface SchedulerProps {
+  headerAction?: ReactNode;
+}
 
 const formatTime = (minutes: number): string => {
   const hours = Math.floor(minutes / 60);
@@ -50,7 +55,7 @@ const initialSchedule: ScheduleItem[] = [
   },
 ];
 
-const Scheduler: React.FC = () => {
+const Scheduler: React.FC<SchedulerProps> = ({ headerAction }) => {
   const [schedule, setSchedule] = useState<ScheduleItem[]>(initialSchedule);
   const [activeBlock, setActiveBlock] = useState<string | null>(null);
   const trackRef = useRef<HTMLDivElement>(null);
@@ -119,34 +124,56 @@ const Scheduler: React.FC = () => {
   };
 
   return (
-    <Box className="scheduler" sx={{ backgroundColor: "rgba(255,255,255,0.18)", borderRadius: 4 }}>
+    <Box
+      className="scheduler"
+      sx={{
+        backgroundColor: "rgba(255,255,255,0.2)",
+        borderRadius: 4,
+        border: "1px solid rgba(255,255,255,0.35)",
+        boxShadow: "inset 0 0 0 1px rgba(255,255,255,0.12)",
+      }}
+    >
       <Stack
-        direction={{ xs: "column", sm: "row" }}
+        direction={{ xs: "column", md: "row" }}
         justifyContent="space-between"
-        alignItems={{ xs: "flex-start", sm: "center" }}
+        alignItems={{ xs: "flex-start", md: "center" }}
         gap={1.5}
         className="scheduler__header"
       >
         <Typography
           variant="h6"
           sx={{
-            fontFamily: '"Fredoka", sans-serif',
-            fontSize: { xs: "1.2rem", md: "1.35rem" },
-            color: "rgba(255,255,255,0.92)",
+            fontSize: { xs: "1.1rem", md: "1.25rem" },
+            color: "rgba(255,255,255,0.95)",
+            letterSpacing: 0.4,
           }}
         >
           Recommended study plan for today:
         </Typography>
-        <Typography
-          variant="subtitle1"
-          className="scheduler__total"
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={{ xs: 1, sm: 2 }}
+          alignItems={{ xs: "flex-start", sm: "center" }}
           sx={{
-            color: "rgba(255,255,255,0.85)",
-            fontWeight: 500,
+            width: "100%",
+            justifyContent: { sm: "flex-end" },
+            flexWrap: "wrap",
+            rowGap: 0.5,
           }}
         >
-          Total study time: {totalDurationLabel}
-        </Typography>
+          <Typography
+            variant="subtitle1"
+            className="scheduler__total"
+            sx={{
+              color: "rgba(255,255,255,0.9)",
+              fontWeight: 500,
+              textAlign: { xs: "left", sm: "right" },
+            }}
+          >
+            Total study time: {totalDurationLabel}
+          </Typography>
+          {headerAction}
+        </Stack>
       </Stack>
       <Box className="scheduler__track-wrapper">
         <Typography className="scheduler__time-label">0000</Typography>

--- a/nala/frontend/nalaLearnscape/src/components/ThreadMap.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/ThreadMap.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import type { Edge, Node } from "@xyflow/react";
-import { ReactFlow, Background, Controls } from "@xyflow/react";
+import { ReactFlow, Controls } from "@xyflow/react";
 
 export interface ThreadMapProps {
   nodes: Node[];
@@ -17,7 +17,6 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ nodes, edges }) => {
       className="threadmap"
       style={{ width: "100%", height: "100%" }}
     >
-      <Background />
       <Controls showInteractive={false} position="bottom-right" />
     </ReactFlow>
   );

--- a/nala/frontend/nalaLearnscape/src/components/ThreadMapSection.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/ThreadMapSection.tsx
@@ -108,6 +108,7 @@ const ThreadMapSection: React.FC = () => {
         py: { xs: 3, md: 4 },
         backgroundColor: "#ffffff",
         boxShadow: "0 22px 45px rgba(44,87,170,0.14)",
+        border: "1px solid rgba(76,115,255,0.12)",
       }}
     >
       <Stack

--- a/nala/frontend/nalaLearnscape/src/components/welcome.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/welcome.tsx
@@ -5,7 +5,6 @@ import {
   Dialog,
   DialogContent,
   DialogTitle,
-  Divider,
   Drawer,
   IconButton,
   Link,
@@ -41,6 +40,25 @@ const Welcome: React.FC = () => {
     setIsDrawerOpen(false);
   };
 
+  const findOutWhyLink = (
+    <Link
+      component="button"
+      type="button"
+      onClick={() => setIsModalOpen(true)}
+      underline="hover"
+      className="welcome__cta"
+      sx={{
+        color: "#FFE08C",
+        fontWeight: 600,
+        fontSize: "0.95rem",
+        letterSpacing: 0.3,
+        "&:hover": { color: "#FFFFFF" },
+      }}
+    >
+      Find out why
+    </Link>
+  );
+
   return (
     <Box
       component="section"
@@ -61,45 +79,46 @@ const Welcome: React.FC = () => {
           px: { xs: 3, md: 5 },
           py: { xs: 3, md: 4 },
           background:
-            "linear-gradient(135deg, rgba(76,115,255,0.96) 0%, rgba(110,162,255,0.9) 60%, rgba(147,193,255,0.95) 100%)",
+            "linear-gradient(135deg, rgba(70,110,255,0.98) 0%, rgba(96,149,255,0.95) 55%, rgba(143,189,255,0.98) 100%)",
           color: "#FFFFFF",
-          boxShadow: "0 24px 60px rgba(44,87,170,0.28)",
+          boxShadow: "0 28px 65px rgba(34,72,168,0.32)",
           overflow: "hidden",
         }}
       >
         <Stack
-          direction="row"
-          spacing={2}
-          alignItems="flex-start"
+          direction={{ xs: "column", md: "row" }}
+          spacing={{ xs: 3, md: 4 }}
+          alignItems={{ xs: "flex-start", md: "center" }}
           justifyContent="space-between"
           className="welcome__header"
         >
-          <Stack direction="row" spacing={2} alignItems="flex-start">
+          <Stack direction="row" spacing={2.5} alignItems="center" sx={{ width: "100%" }}>
             <IconButton
               className="welcome__menu"
               onClick={() => setIsDrawerOpen(true)}
               sx={{
                 borderRadius: 3,
-                backgroundColor: "rgba(255,255,255,0.18)",
+                backgroundColor: "rgba(255,255,255,0.2)",
                 color: "inherit",
-                border: "1px solid rgba(255,255,255,0.36)",
+                border: "1px solid rgba(255,255,255,0.38)",
                 p: 1,
                 "&:hover": {
-                  backgroundColor: "rgba(255,255,255,0.28)",
+                  backgroundColor: "rgba(255,255,255,0.3)",
                 },
               }}
               aria-label="Open navigation menu"
             >
               <MenuRoundedIcon />
             </IconButton>
-            <Box className="welcome__title-group">
+            <Box className="welcome__title-group" sx={{ flexGrow: 1 }}>
               <Typography
                 variant="h3"
                 sx={{
                   mb: 1,
                   color: "#FFFFFF",
-                  fontSize: { xs: "1.9rem", md: "2.3rem" },
+                  fontSize: { xs: "1.95rem", md: "2.4rem" },
                   lineHeight: 1.05,
+                  letterSpacing: 0.2,
                 }}
               >
                 Welcome back,
@@ -107,56 +126,85 @@ const Welcome: React.FC = () => {
                   {" "}John!
                 </Box>
               </Typography>
-              <Link
-                component="button"
-                type="button"
-                onClick={() => setIsModalOpen(true)}
-                underline="hover"
-                className="welcome__cta"
+              <Typography
+                variant="subtitle1"
                 sx={{
-                  color: "#FFFFFF",
-                  fontWeight: 600,
-                  fontSize: "1rem",
-                  letterSpacing: 0.3,
-                  "&:hover": { color: "#FFE08C" },
+                  color: "rgba(255,255,255,0.82)",
+                  fontFamily: '"GlacialIndifference", sans-serif',
+                  letterSpacing: 0.4,
                 }}
               >
-                Find out why
-              </Link>
+                Your personalised schedule is ready. Drag the blocks to reshape your day.
+              </Typography>
             </Box>
           </Stack>
           <Stack
             direction="column"
             alignItems="center"
-            spacing={0.5}
+            spacing={1.2}
             sx={{
-              backgroundColor: "rgba(255,255,255,0.18)",
-              borderRadius: 4,
-              px: 2,
-              py: 1.5,
+              backgroundColor: "rgba(255,255,255,0.22)",
+              borderRadius: 5,
+              px: 2.5,
+              py: 2.5,
               border: "1px solid rgba(255,255,255,0.35)",
-              minWidth: 72,
+              minWidth: 96,
+              boxShadow: "0 18px 36px rgba(16,46,120,0.2)",
             }}
           >
-            <LocalFireDepartmentRoundedIcon fontSize="large" sx={{ color: "#FFE08C" }} />
-            <Typography variant="subtitle2" sx={{ fontWeight: 700, letterSpacing: 1 }}>
-              25 Days
+            <Box
+              sx={{
+                position: "relative",
+                width: 62,
+                height: 62,
+                borderRadius: "50%",
+                background: "linear-gradient(180deg, #4C73FF 0%, #2848D1 100%)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                color: "#FFFFFF",
+                boxShadow: "0 12px 24px rgba(28,62,158,0.35)",
+              }}
+            >
+              <LocalFireDepartmentRoundedIcon sx={{ fontSize: 36 }} />
+              <Typography
+                variant="subtitle1"
+                sx={{
+                  position: "absolute",
+                  bottom: 10,
+                  fontFamily: '"Fredoka", sans-serif',
+                  fontWeight: 700,
+                  fontSize: "1.05rem",
+                }}
+              >
+                25
+              </Typography>
+            </Box>
+            <Typography
+              variant="subtitle2"
+              sx={{
+                color: "#FFFFFF",
+                fontWeight: 600,
+                letterSpacing: 1,
+                fontFamily: '"Fredoka", sans-serif',
+              }}
+            >
+              Day Streak
             </Typography>
-            <Typography variant="caption" sx={{ color: "rgba(255,255,255,0.85)" }}>
-              Streak
+            <Typography
+              variant="caption"
+              sx={{
+                color: "rgba(255,255,255,0.8)",
+                letterSpacing: 1,
+                fontFamily: '"GlacialIndifference", sans-serif',
+              }}
+            >
+              Keep it going!
             </Typography>
           </Stack>
         </Stack>
 
-        <Divider
-          sx={{
-            my: { xs: 2.5, md: 3 },
-            borderColor: "rgba(255,255,255,0.28)",
-            borderBottomWidth: 1,
-          }}
-        />
-
-        <Scheduler />
+        <Scheduler headerAction={findOutWhyLink} />
       </Paper>
 
       <LearningStyleOverview />

--- a/nala/frontend/nalaLearnscape/src/main.tsx
+++ b/nala/frontend/nalaLearnscape/src/main.tsx
@@ -27,6 +27,24 @@ createRoot(document.getElementById("root")!).render(
           h3: {
             fontFamily: theme.typography.h3.fontFamily,
           },
+          h4: {
+            fontFamily: theme.typography.h4?.fontFamily,
+          },
+          h5: {
+            fontFamily: theme.typography.h5?.fontFamily,
+          },
+          h6: {
+            fontFamily: theme.typography.h6?.fontFamily,
+          },
+          p: {
+            fontFamily: theme.typography.fontFamily,
+          },
+          span: {
+            fontFamily: theme.typography.fontFamily,
+          },
+          button: {
+            fontFamily: theme.typography.button?.fontFamily,
+          },
           a: {
             color: "inherit",
           },

--- a/nala/frontend/nalaLearnscape/src/pages/Home.css
+++ b/nala/frontend/nalaLearnscape/src/pages/Home.css
@@ -1,5 +1,6 @@
 .home {
   background: #e8f1ff;
+  font-family: "GlacialIndifference", sans-serif;
 }
 
 .home__below {
@@ -20,6 +21,15 @@
   gap: 24px;
   min-height: 340px;
   position: relative;
+}
+
+.welcome__card::after {
+  content: "";
+  position: absolute;
+  inset: 24px;
+  border-radius: 36px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  pointer-events: none;
 }
 
 .welcome__header {
@@ -55,17 +65,18 @@
   font-family: "Fredoka", sans-serif;
   font-weight: 600;
   font-size: 1rem;
-  color: rgba(255, 255, 255, 0.9);
+  color: #2447b5;
 }
 
 .scheduler__track {
   position: relative;
   height: 140px;
-  border-radius: 30px;
-  border: 1px solid rgba(255, 255, 255, 0.35);
-  background: rgba(255, 255, 255, 0.22);
+  border-radius: 32px;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  background: rgba(255, 255, 255, 0.95);
   overflow: hidden;
   padding: 20px 0;
+  box-shadow: inset 0 0 0 1px rgba(76, 115, 255, 0.12);
 }
 
 .scheduler__markers {
@@ -88,13 +99,13 @@
 .scheduler__marker-line {
   width: 2px;
   flex: 1;
-  background: rgba(255, 255, 255, 0.28);
+  background: rgba(76, 115, 255, 0.2);
 }
 
 .scheduler__marker-label {
   font-size: 0.75rem;
   font-family: "GlacialIndifference", sans-serif;
-  color: rgba(255, 255, 255, 0.88);
+  color: #1a2c5e;
 }
 
 .scheduler__block {
@@ -178,7 +189,7 @@
 .learning-style-card__legend-item {
   border-radius: 18px;
   padding: 12px 16px;
-  background: rgba(232, 241, 255, 0.5);
+  background: rgba(232, 241, 255, 0.6);
 }
 
 .learning-style-card__legend-color {
@@ -209,8 +220,36 @@
 
 .threadmap-section__body {
   border-radius: 28px;
-  background: #f5f8ff;
+  background: linear-gradient(180deg, rgba(232, 241, 255, 0.8) 0%, rgba(244, 248, 255, 0.95) 100%);
   padding: 12px;
+  min-height: 300px;
+}
+
+.threadmap {
+  background: transparent;
+  border-radius: 20px;
+}
+
+.threadmap .react-flow__background {
+  background: transparent;
+}
+
+.threadmap .react-flow__controls {
+  box-shadow: none;
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 12px;
+  border: 1px solid rgba(76, 115, 255, 0.2);
+}
+
+.threadmap .react-flow__node {
+  font-family: "GlacialIndifference", sans-serif;
+  font-weight: 600;
+  color: #1a2c5e;
+  font-size: 0.95rem;
+}
+
+.threadmap .react-flow__edge-path {
+  stroke: rgba(76, 115, 255, 0.6) !important;
 }
 
 @media (max-width: 1024px) {

--- a/nala/frontend/nalaLearnscape/src/pages/Home.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/Home.tsx
@@ -30,6 +30,7 @@ const Home: React.FC = () => {
                   background:
                     "linear-gradient(180deg, rgba(216,229,255,0.85) 0%, rgba(241,245,255,0.9) 100%)",
                   boxShadow: "inset 0 0 0 1px rgba(76,115,255,0.1)",
+                  border: "1px solid rgba(76,115,255,0.12)",
                 }}
               >
                 <Typography

--- a/nala/frontend/nalaLearnscape/src/theme.ts
+++ b/nala/frontend/nalaLearnscape/src/theme.ts
@@ -35,8 +35,36 @@ const theme = createTheme({
       fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
       fontWeight: 700,
     },
+    h4: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    h5: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    h6: {
+      fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
+      fontWeight: 700,
+    },
+    subtitle1: {
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    },
+    subtitle2: {
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    },
+    body1: {
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    },
+    body2: {
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    },
     button: {
       textTransform: "none",
+      fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 600,
+    },
+    caption: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
     },
   },


### PR DESCRIPTION
## Summary
- refresh the welcome dashboard card to match the reference, including the streak flame badge, menu drawer, and embedded "Find out why" link
- restyle the scheduler timeline, learning style overview, and thread map section so the timeline, pie chart, and thread map all render and follow the updated palette and typography
- apply Fredoka and Glacial Indifference through the MUI theme and global styles so headers and body copy consistently use the specified fonts

## Testing
- `npm run lint` *(fails: missing @eslint/js because the registry blocks package downloads in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d581120ec883329964dde9e45a3b42