### PR TITLE
refactor: rebuild thread map with reactflow

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/ThreadMap.css
+++ b/nala/frontend/nalaLearnscape/src/pages/ThreadMap.css
@@ -1,0 +1,175 @@
+.thread-map-page {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  text-align: left;
+  color: #102a43;
+}
+
+.thread-map-header h1 {
+  font-size: 2rem;
+  margin-bottom: 0.5rem;
+  color: #0b3c61;
+}
+
+.thread-map-header p {
+  margin: 0;
+  max-width: 640px;
+  line-height: 1.6;
+  color: #335f7c;
+}
+
+.thread-map-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: 1.75rem;
+  align-items: start;
+}
+
+.thread-map-controls {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 16px 32px rgba(15, 62, 92, 0.08);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  position: sticky;
+  top: 2rem;
+}
+
+.thread-map-controls h2 {
+  font-size: 1.125rem;
+  margin: 0 0 0.75rem;
+  color: #0b3c61;
+}
+
+.thread-map-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.thread-map-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-weight: 500;
+}
+
+.thread-map-form input,
+.thread-map-form select {
+  border: 1px solid #c7d9ea;
+  border-radius: 10px;
+  padding: 0.6rem 0.75rem;
+  font-size: 0.95rem;
+  color: #0b3c61;
+  background: #f6fbff;
+}
+
+.thread-map-form input[type="range"] {
+  padding: 0;
+  accent-color: #0288d1;
+}
+
+.thread-map-form select:focus,
+.thread-map-form input:focus {
+  outline: 2px solid rgba(2, 136, 209, 0.35);
+  outline-offset: 1px;
+}
+
+.thread-map-form button {
+  margin-top: 0.5rem;
+  border: none;
+  background: linear-gradient(135deg, #0288d1, #03a9f4);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(2, 136, 209, 0.25);
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.thread-map-form button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(2, 136, 209, 0.3);
+}
+
+.thread-map-canvas {
+  background: radial-gradient(circle at top left, #f5fbff 0%, #e0f2ff 100%);
+  border-radius: 20px;
+  box-shadow: inset 0 0 0 1px rgba(2, 136, 209, 0.08),
+    0 20px 40px rgba(12, 70, 104, 0.18);
+  min-height: 640px;
+  position: relative;
+  overflow: hidden;
+}
+
+.thread-map-canvas .reactflow-wrapper {
+  width: 100%;
+  height: 100%;
+}
+
+.mindmap-flow .react-flow__node {
+  cursor: grab;
+}
+
+.mindmap-flow .react-flow__node:active {
+  cursor: grabbing;
+}
+
+.mindmap-node {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  transform: translate(-50%, -50%);
+}
+
+.mindmap-node-circle {
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #ffffff;
+  font-size: 1.25rem;
+  font-weight: 700;
+  box-shadow: 0 12px 30px rgba(11, 60, 97, 0.25);
+}
+
+.mindmap-node-label {
+  font-weight: 600;
+  color: #0b3c61;
+  text-align: center;
+  max-width: 160px;
+  line-height: 1.3;
+  text-shadow: 0 2px 6px rgba(11, 60, 97, 0.15);
+}
+
+.mindmap-node--selected .mindmap-node-circle {
+  box-shadow: 0 0 0 4px rgba(2, 136, 209, 0.25), 0 16px 36px rgba(11, 60, 97, 0.3);
+}
+
+.mindmap-node--selected .mindmap-node-label {
+  color: #026aa7;
+}
+
+.mindmap-flow .react-flow__edge-path {
+  stroke-linecap: round;
+}
+
+.mindmap-flow .react-flow__minimap-mask {
+  fill: rgba(2, 136, 209, 0.15);
+}
+
+@media (max-width: 960px) {
+  .thread-map-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .thread-map-controls {
+    position: static;
+  }
+}

--- a/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
@@ -1,175 +1,638 @@
-import React, { useCallback, useEffect, useState } from "react";
-import {
-  ReactFlow,
+import React, {
+  FormEvent,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import ReactFlow, {
   Background,
+  Connection,
   Controls,
+  Edge,
   MiniMap,
-  useNodesState,
-  useEdgesState,
-  addEdge,
-  Position,
-} from "@xyflow/react";
-import * as d3 from "d3";
+  Node,
+  NodeProps,
+  OnEdgesChange,
+  OnNodesChange,
+  applyEdgeChanges,
+  applyNodeChanges,
+  useNodesInitialized,
+  useReactFlow,
+  ReactFlowProvider,
+} from "reactflow";
+import { nanoid } from "nanoid";
+import {
+  forceCenter,
+  forceCollide,
+  forceLink,
+  forceManyBody,
+  forceSimulation,
+} from "d3-force";
 
-import "@xyflow/react/dist/style.css";
+import "reactflow/dist/style.css";
+import "./ThreadMap.css";
 
-interface NodeData {
-  number: number;
+type MindMapNodeData = {
   label: string;
-}
-
-const ConceptNode = ({ data }: { data: NodeData }) => {
-  return (
-    <div
-      style={{
-        width: "100px",
-        height: "100px",
-        borderRadius: "50%",
-        backgroundColor: "#00bcd4",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        color: "#fff",
-        fontSize: "18px",
-        fontWeight: "bold",
-        textAlign: "center",
-      }}
-    >
-      <div>{data.number}</div>
-      <div>{data.label}</div>
-    </div>
-  );
+  number: number;
+  color: string;
+  radius: number;
 };
 
-const TopicNode = ({ data }: { data: NodeData }) => {
-  return (
-    <div
-      style={{
-        width: "200px",
-        height: "200px",
-        borderRadius: "50%",
-        backgroundColor: "#00bcd4",
-        display: "flex",
-        alignItems: "center",
-        justifyContent: "center",
-        color: "#fff",
-        fontSize: "18px",
-        fontWeight: "bold",
-        textAlign: "center",
-      }}
-    >
-      <div>{data.number}</div>
-      <div>{data.label}</div>
-    </div>
-  );
+type MindMapNode = Node<MindMapNodeData>;
+
+type SimulationNode = {
+  id: string;
+  x: number;
+  y: number;
+  vx?: number;
+  vy?: number;
+  data: MindMapNodeData;
 };
 
-const nodeDefaults = {
-  sourcePosition: Position.Right,
-  targetPosition: Position.Left,
-};
+const canvasWidth = 960;
+const canvasHeight = 640;
 
-const initialNodes = [
+const baseNodes: Array<Omit<MindMapNodeData, "color"> & { id: string; color?: string }> = [
+  { id: "logic", label: "Logic", number: 3, radius: 64, color: "#0288D1" },
   {
-    id: "1",
-    type: ConceptNode,
-    position: { x: 0, y: 150 },
-    data: { label: "default style 1" },
-    ...nodeDefaults,
+    id: "truth-tables",
+    label: "Truth Tables",
+    number: 3,
+    radius: 36,
+    color: "#03A9F4",
   },
   {
-    id: "2",
-    type: ConceptNode,
-    position: { x: 250, y: 0 },
-    data: { label: "default style 2" },
-    ...nodeDefaults,
+    id: "logical-operators",
+    label: "Logical Operators",
+    number: 3,
+    radius: 36,
+    color: "#03A9F4",
   },
   {
-    id: "3",
-    position: { x: 250, y: 150 },
-    data: { label: "default style 3" },
-    ...nodeDefaults,
+    id: "inference-rules",
+    label: "Inference Rules",
+    number: 4,
+    radius: 40,
+    color: "#29B6F6",
   },
   {
-    id: "4",
-    position: { x: 250, y: 300 },
-    data: { label: "default style 4" },
-    ...nodeDefaults,
+    id: "proof-techniques",
+    label: "Proof Techniques",
+    number: 3,
+    radius: 36,
+    color: "#4FC3F7",
+  },
+  {
+    id: "de-morgan",
+    label: "De Morgan's Laws",
+    number: 3,
+    radius: 36,
+    color: "#4FC3F7",
+  },
+  {
+    id: "equivalence",
+    label: "Logical Equivalence Laws",
+    number: 3,
+    radius: 36,
+    color: "#03A9F4",
+  },
+  {
+    id: "propositions",
+    label: "Propositions",
+    number: 2,
+    radius: 32,
+    color: "#00BCD4",
+  },
+  {
+    id: "set-theory",
+    label: "Set Theory",
+    number: 3,
+    radius: 44,
+    color: "#26C6DA",
   },
 ];
 
-const initialEdges = [
-  {
-    id: "e1-2",
-    source: "1",
-    target: "2",
-  },
-  {
-    id: "e1-3",
-    source: "1",
-    target: "3",
-  },
-  {
-    id: "e1-4",
-    source: "1",
-    target: "4",
-  },
+const initialEdges: Edge[] = [
+  { id: "logic-truth", source: "logic", target: "truth-tables" },
+  { id: "logic-operators", source: "logic", target: "logical-operators" },
+  { id: "logic-inference", source: "logic", target: "inference-rules" },
+  { id: "logic-proof", source: "logic", target: "proof-techniques" },
+  { id: "logic-morgan", source: "logic", target: "de-morgan" },
+  { id: "logic-equivalence", source: "logic", target: "equivalence" },
+  { id: "logic-propositions", source: "logic", target: "propositions" },
+  { id: "logic-set", source: "logic", target: "set-theory" },
 ];
+
+const colorPalette = [
+  "#03A9F4",
+  "#29B6F6",
+  "#26C6DA",
+  "#00ACC1",
+  "#4DD0E1",
+  "#00BCD4",
+  "#4FC3F7",
+  "#0288D1",
+];
+
+const createInitialNodes = (): MindMapNode[] => {
+  const centerX = canvasWidth / 2;
+  const centerY = canvasHeight / 2;
+
+  return baseNodes.map((node, index) => {
+    const angle = (index / Math.max(baseNodes.length, 1)) * Math.PI * 2;
+    const radius = index === 0 ? 0 : 220 + Math.random() * 40;
+
+    return {
+      id: node.id,
+      type: "mindmap",
+      data: {
+        label: node.label,
+        number: node.number,
+        color: node.color ?? colorPalette[index % colorPalette.length],
+        radius: node.radius,
+      },
+      position: {
+        x: centerX + Math.cos(angle) * radius,
+        y: centerY + Math.sin(angle) * radius,
+      },
+    } satisfies MindMapNode;
+  });
+};
+
+const applyForceLayout = (nodes: MindMapNode[], edges: Edge[]): MindMapNode[] => {
+  if (nodes.length === 0) {
+    return nodes;
+  }
+
+  const centerX = canvasWidth / 2;
+  const centerY = canvasHeight / 2;
+
+  const simNodes: SimulationNode[] = nodes.map((node) => ({
+    id: node.id,
+    x:
+      node.position?.x ??
+      centerX + (Math.random() - 0.5) * Math.max(canvasWidth / 4, 160),
+    y:
+      node.position?.y ??
+      centerY + (Math.random() - 0.5) * Math.max(canvasHeight / 4, 160),
+    data: node.data,
+  }));
+
+  const simEdges = edges.map((edge) => ({
+    source: edge.source,
+    target: edge.target,
+  }));
+
+  const simulation = forceSimulation(simNodes)
+    .force(
+      "charge",
+      forceManyBody().strength((node) => -220 - (node?.data.radius ?? 40) * 4),
+    )
+    .force("center", forceCenter(centerX, centerY))
+    .force(
+      "collision",
+      forceCollide<SimulationNode>().radius((node) => node.data.radius + 36),
+    )
+    .force(
+      "link",
+      forceLink<SimulationNode, { source: string; target: string }>(simEdges)
+        .id((node) => node.id)
+        .distance(160)
+        .strength(0.7),
+    )
+    .alphaDecay(0.12)
+    .stop();
+
+  for (let i = 0; i < 80; i += 1) {
+    simulation.tick();
+  }
+
+  const nodeLookup = new Map(simNodes.map((node) => [node.id, node]));
+
+  return nodes.map((node) => {
+    const simulated = nodeLookup.get(node.id);
+    if (!simulated) {
+      return node;
+    }
+
+    return {
+      ...node,
+      position: {
+        x: simulated.x,
+        y: simulated.y,
+      },
+    } satisfies MindMapNode;
+  });
+};
+
+const MindMapNodeComponent: React.FC<NodeProps<MindMapNodeData>> = ({
+  data,
+  selected,
+}) => {
+  const diameter = data.radius * 2;
+
+  return (
+    <div
+      className={`mindmap-node${selected ? " mindmap-node--selected" : ""}`}
+      style={{ width: diameter }}
+    >
+      <div
+        className="mindmap-node-circle"
+        style={{ width: diameter, height: diameter, background: data.color }}
+      >
+        <span>{data.number}</span>
+      </div>
+      <div className="mindmap-node-label">{data.label}</div>
+    </div>
+  );
+};
 
 const nodeTypes = {
-  conceptNode: ConceptNode,
-  topicNode: TopicNode,
+  mindmap: MindMapNodeComponent,
 };
 
-const Flow = () => {
-  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes);
-  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges);
+type MindMapCanvasProps = {
+  nodes: MindMapNode[];
+  edges: Edge[];
+  onNodesChange: OnNodesChange;
+  onEdgesChange: OnEdgesChange;
+  onConnect: (connection: Connection) => void;
+};
 
-  const onConnect = useCallback(
-    (params) => setEdges((els) => addEdge(params, els)),
-    []
-  );
+const MindMapCanvas: React.FC<MindMapCanvasProps> = ({
+  nodes,
+  edges,
+  onNodesChange,
+  onEdgesChange,
+  onConnect,
+}) => {
+  const reactFlow = useReactFlow();
+  const nodesInitialized = useNodesInitialized();
 
-  // D3 Force Simulation
   useEffect(() => {
-    const simulation = d3
-      .forceSimulation(nodes)
-      .force("charge", d3.forceManyBody().strength(-500)) // Prevent nodes from overlapping
-      .force("center", d3.forceCenter(250, 250)) // Center the nodes
-      .force("collision", d3.forceCollide(100)) // Prevent overlap with defined radius
-      .on("tick", () => {
-        const newNodes = nodes.map((node, index) => {
-          node.position = {
-            x: simulation.nodes()[index].x,
-            y: simulation.nodes()[index].y,
-          };
-          return node;
-        });
-        setNodes(newNodes); // Update node positions
-      });
+    if (nodesInitialized) {
+      reactFlow.fitView({ padding: 0.2, duration: 400 });
+    }
+  }, [nodesInitialized, nodes.length, reactFlow]);
 
-    simulation.alpha(1).restart(); // Restart the simulation
-
-    return () => {
-      simulation.stop(); // Stop the simulation on unmount
-    };
-  }, [nodes]);
+  const defaultEdgeOptions = useMemo(
+    () => ({
+      type: "smoothstep" as const,
+      animated: false,
+      style: { stroke: "#0b3c61", strokeWidth: 2 },
+    }),
+    [],
+  );
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      nodeTypes={nodeTypes}
-      edges={edges}
-      onNodesChange={onNodesChange}
-      onEdgesChange={onEdgesChange}
-      onConnect={onConnect}
-      fitView
-    >
-      <Background />
-      <Controls />
-      <MiniMap />
-    </ReactFlow>
+    <ReactFlowWrapper>
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        onNodesChange={onNodesChange}
+        onEdgesChange={onEdgesChange}
+        onConnect={onConnect}
+        panOnScroll
+        zoomOnScroll
+        fitView
+        fitViewOptions={{ padding: 0.2 }}
+        defaultEdgeOptions={defaultEdgeOptions}
+        elementsSelectable
+        nodesConnectable
+        nodesDraggable
+        className="mindmap-flow"
+      >
+        <Background color="#d0e7ff" gap={32} />
+        <Controls showInteractive={false} position="top-left" />
+        <MiniMap nodeStrokeColor="#0b3c61" nodeColor="#f2fbff" zoomable pannable />
+      </ReactFlow>
+    </ReactFlowWrapper>
   );
 };
 
-export default Flow;
+const ReactFlowWrapper: React.FC<React.PropsWithChildren> = ({ children }) => {
+  return <div className="reactflow-wrapper">{children}</div>;
+};
+
+const slugify = (value: string) =>
+  value
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)+/g, "");
+
+const ThreadMap: React.FC = () => {
+  const [nodes, setNodes] = useState<MindMapNode[]>(() =>
+    applyForceLayout(createInitialNodes(), initialEdges),
+  );
+  const [edges, setEdges] = useState<Edge[]>(initialEdges);
+
+  const edgesRef = useRef(edges);
+  useEffect(() => {
+    edgesRef.current = edges;
+    setNodes((current) => applyForceLayout(current, edges));
+  }, [edges]);
+
+  const onNodesChange = useCallback<OnNodesChange>((changes) => {
+    setNodes((currentNodes) => applyNodeChanges(changes, currentNodes));
+  }, []);
+
+  const onEdgesChange = useCallback<OnEdgesChange>((changes) => {
+    setEdges((currentEdges) => applyEdgeChanges(changes, currentEdges));
+  }, []);
+
+  const onConnect = useCallback(
+    (connection: Connection) => {
+      if (!connection.source || !connection.target) {
+        return;
+      }
+
+      setEdges((currentEdges) => {
+        const alreadyExists = currentEdges.some(
+          (edge) =>
+            edge.source === connection.source && edge.target === connection.target,
+        );
+
+        if (alreadyExists) {
+          return currentEdges;
+        }
+
+        const newEdge: Edge = {
+          id: `edge-${connection.source}-${connection.target}-${nanoid(6)}`,
+          source: connection.source,
+          target: connection.target,
+          type: "smoothstep",
+          animated: false,
+        };
+
+        return [...currentEdges, newEdge];
+      });
+    },
+    [],
+  );
+
+  const [nodeForm, setNodeForm] = useState({
+    label: "",
+    number: 1,
+    radius: 40,
+  });
+
+  const [edgeForm, setEdgeForm] = useState(() => ({
+    source: initialEdges[0]?.source ?? baseNodes[0]?.id ?? "",
+    target: initialEdges[0]?.target ?? baseNodes[1]?.id ?? "",
+  }));
+
+  useEffect(() => {
+    setEdgeForm((previous) => {
+      const hasSource = nodes.some((node) => node.id === previous.source);
+      const hasTarget = nodes.some((node) => node.id === previous.target);
+
+      let nextSource = previous.source;
+      let nextTarget = previous.target;
+
+      if (!hasSource) {
+        nextSource = nodes[0]?.id ?? "";
+      }
+
+      if (!hasTarget) {
+        nextTarget = nodes.find((node) => node.id !== nextSource)?.id ?? "";
+      }
+
+      if (nextSource === previous.source && nextTarget === previous.target) {
+        return previous;
+      }
+
+      return { source: nextSource, target: nextTarget };
+    });
+  }, [nodes]);
+
+  const updateNodesWithLayout = useCallback(
+    (updater: (nodes: MindMapNode[]) => MindMapNode[]) => {
+      setNodes((currentNodes) => {
+        const updatedNodes = updater(currentNodes);
+        return applyForceLayout(updatedNodes, edgesRef.current);
+      });
+    },
+    [],
+  );
+
+  const handleAddNode = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const trimmedLabel = nodeForm.label.trim();
+
+      if (!trimmedLabel) {
+        return;
+      }
+
+      updateNodesWithLayout((currentNodes) => {
+        const baseId = slugify(trimmedLabel) || `node-${nanoid(4)}`;
+        let uniqueId = baseId;
+        let suffix = 1;
+        while (currentNodes.some((node) => node.id === uniqueId)) {
+          uniqueId = `${baseId}-${suffix}`;
+          suffix += 1;
+        }
+
+        const color = colorPalette[currentNodes.length % colorPalette.length];
+
+        const newNode: MindMapNode = {
+          id: uniqueId,
+          type: "mindmap",
+          data: {
+            label: trimmedLabel,
+            number: nodeForm.number,
+            radius: nodeForm.radius,
+            color,
+          },
+          position: {
+            x: canvasWidth / 2 + (Math.random() - 0.5) * 80,
+            y: canvasHeight / 2 + (Math.random() - 0.5) * 80,
+          },
+        };
+
+        setEdgeForm((previous) => ({
+          source: previous.source || uniqueId,
+          target: previous.target || uniqueId,
+        }));
+
+        return [...currentNodes, newNode];
+      });
+
+      setNodeForm((current) => ({ ...current, label: "" }));
+    },
+    [nodeForm.label, nodeForm.number, nodeForm.radius, updateNodesWithLayout],
+  );
+
+  const handleAddEdge = useCallback(
+    (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+
+      if (!edgeForm.source || !edgeForm.target || edgeForm.source === edgeForm.target) {
+        return;
+      }
+
+      setEdges((currentEdges) => {
+        const exists = currentEdges.some(
+          (edge) => edge.source === edgeForm.source && edge.target === edgeForm.target,
+        );
+
+        if (exists) {
+          return currentEdges;
+        }
+
+        const newEdge: Edge = {
+          id: `edge-${edgeForm.source}-${edgeForm.target}-${nanoid(6)}`,
+          source: edgeForm.source,
+          target: edgeForm.target,
+          type: "smoothstep",
+          animated: false,
+        };
+
+        return [...currentEdges, newEdge];
+      });
+    },
+    [edgeForm.source, edgeForm.target],
+  );
+
+  return (
+    <div className="thread-map-page">
+      <div className="thread-map-header">
+        <h1>Concept Threads</h1>
+        <p>
+          Explore logical concepts in an interactive mind map. Nodes repel each
+          other to avoid overlap, while edges keep related topics connected.
+          Add your own concepts or relationships to grow the network.
+        </p>
+      </div>
+
+      <div className="thread-map-layout">
+        <aside className="thread-map-controls">
+          <section>
+            <h2>Add a concept</h2>
+            <form className="thread-map-form" onSubmit={handleAddNode}>
+              <label>
+                Label
+                <input
+                  type="text"
+                  value={nodeForm.label}
+                  onChange={(event) =>
+                    setNodeForm((current) => ({
+                      ...current,
+                      label: event.target.value,
+                    }))
+                  }
+                  placeholder="e.g. Predicate Logic"
+                  required
+                />
+              </label>
+              <label>
+                Concept number
+                <input
+                  type="number"
+                  min={0}
+                  max={99}
+                  value={nodeForm.number}
+                  onChange={(event) =>
+                    setNodeForm((current) => ({
+                      ...current,
+                      number: Number(event.target.value),
+                    }))
+                  }
+                />
+              </label>
+              <label>
+                Node radius
+                <input
+                  type="range"
+                  min={28}
+                  max={72}
+                  value={nodeForm.radius}
+                  onChange={(event) =>
+                    setNodeForm((current) => ({
+                      ...current,
+                      radius: Number(event.target.value),
+                    }))
+                  }
+                />
+              </label>
+              <button type="submit">Add concept</button>
+            </form>
+          </section>
+
+          <section>
+            <h2>Create a connection</h2>
+            <form className="thread-map-form" onSubmit={handleAddEdge}>
+              <label>
+                Source concept
+                <select
+                  value={edgeForm.source}
+                  onChange={(event) =>
+                    setEdgeForm((current) => ({
+                      ...current,
+                      source: event.target.value,
+                    }))
+                  }
+                >
+                  {nodes.map((node) => (
+                    <option key={node.id} value={node.id}>
+                      {node.data.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Target concept
+                <select
+                  value={edgeForm.target}
+                  onChange={(event) =>
+                    setEdgeForm((current) => ({
+                      ...current,
+                      target: event.target.value,
+                    }))
+                  }
+                >
+                  {nodes
+                    .filter((node) => node.id !== edgeForm.source)
+                    .map((node) => (
+                      <option key={node.id} value={node.id}>
+                        {node.data.label}
+                      </option>
+                    ))}
+                </select>
+              </label>
+              <button
+                type="submit"
+                disabled={
+                  !edgeForm.source ||
+                  !edgeForm.target ||
+                  edgeForm.source === edgeForm.target
+                }
+              >
+                Add connection
+              </button>
+            </form>
+          </section>
+        </aside>
+
+        <div className="thread-map-canvas">
+          <ReactFlowProvider>
+            <MindMapCanvas
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onConnect={onConnect}
+            />
+          </ReactFlowProvider>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ThreadMap;


### PR DESCRIPTION
## Summary
- rebuild the ThreadMap page on top of React Flow, running a force simulation to keep concepts separated while preserving interactive dragging and connections
- add custom circular node rendering plus forms for adding labelled concepts and connections with automatic layout recalculation
- refresh the ThreadMap styles so the React Flow canvas and node presentation match the desired concept-map aesthetic

## Testing
- npm run build *(fails: TypeScript cannot find the existing project's missing ambient type declarations such as @types/react and vite)*

------
https://chatgpt.com/codex/tasks/task_e_68d7af0f2e7083328f85667fe99e36aa