### PR TITLE
Use MUI PieChart and align typography fonts

### DIFF
--- a/nala/frontend/nalaLearnscape/package-lock.json
+++ b/nala/frontend/nalaLearnscape/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mui/icons-material": "^5.16.7",
         "@mui/material": "^5.16.7",
+        "@mui/x-charts": "^7.22.2",
         "@tailwindcss/vite": "^4.1.13",
         "@xyflow/react": "^12.8.5",
         "classcat": "^5.0.5",

--- a/nala/frontend/nalaLearnscape/package.json
+++ b/nala/frontend/nalaLearnscape/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@mui/icons-material": "^5.16.7",
     "@mui/material": "^5.16.7",
+    "@mui/x-charts": "^7.22.2",
     "@tailwindcss/vite": "^4.1.13",
     "@xyflow/react": "^12.8.5",
     "classcat": "^5.0.5",

--- a/nala/frontend/nalaLearnscape/src/App.css
+++ b/nala/frontend/nalaLearnscape/src/App.css
@@ -1,5 +1,25 @@
 @import "tailwindcss";
 
+@theme {
+  --font-fredoka: "Fredoka", "GlacialIndifference", sans-serif;
+  --font-glacial: "GlacialIndifference", "Helvetica Neue", Arial, sans-serif;
+}
+
+@layer base {
+  body {
+    @apply font-glacial font-normal;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-fredoka font-bold;
+  }
+}
+
 @layer reactflow {
   @import "@xyflow/react/dist/style.css";
 }

--- a/nala/frontend/nalaLearnscape/src/main.tsx
+++ b/nala/frontend/nalaLearnscape/src/main.tsx
@@ -16,34 +16,44 @@ createRoot(document.getElementById("root")!).render(
           body: {
             backgroundColor: theme.palette.background.default,
             fontFamily: theme.typography.fontFamily,
+            fontWeight: theme.typography.fontWeightRegular,
             color: theme.palette.text.primary,
           },
           h1: {
             fontFamily: theme.typography.h1.fontFamily,
+            fontWeight: theme.typography.h1.fontWeight,
           },
           h2: {
             fontFamily: theme.typography.h2.fontFamily,
+            fontWeight: theme.typography.h2.fontWeight,
           },
           h3: {
             fontFamily: theme.typography.h3.fontFamily,
+            fontWeight: theme.typography.h3.fontWeight,
           },
           h4: {
             fontFamily: theme.typography.h4?.fontFamily,
+            fontWeight: theme.typography.h4?.fontWeight,
           },
           h5: {
             fontFamily: theme.typography.h5?.fontFamily,
+            fontWeight: theme.typography.h5?.fontWeight,
           },
           h6: {
             fontFamily: theme.typography.h6?.fontFamily,
+            fontWeight: theme.typography.h6?.fontWeight,
           },
           p: {
             fontFamily: theme.typography.fontFamily,
+            fontWeight: theme.typography.fontWeightRegular,
           },
           span: {
             fontFamily: theme.typography.fontFamily,
+            fontWeight: theme.typography.fontWeightRegular,
           },
           button: {
             fontFamily: theme.typography.button?.fontFamily,
+            fontWeight: theme.typography.button?.fontWeight,
           },
           a: {
             color: "inherit",

--- a/nala/frontend/nalaLearnscape/src/theme.ts
+++ b/nala/frontend/nalaLearnscape/src/theme.ts
@@ -23,6 +23,9 @@ const theme = createTheme({
   },
   typography: {
     fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+    fontWeightRegular: 400,
+    fontWeightMedium: 500,
+    fontWeightBold: 700,
     h1: {
       fontFamily: '"Fredoka", "GlacialIndifference", sans-serif',
       fontWeight: 700,
@@ -49,23 +52,28 @@ const theme = createTheme({
     },
     subtitle1: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 400,
     },
     subtitle2: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 400,
     },
     body1: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 400,
     },
     body2: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 400,
     },
     button: {
       textTransform: "none",
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
-      fontWeight: 600,
+      fontWeight: 400,
     },
     caption: {
       fontFamily: '"GlacialIndifference", "Helvetica Neue", Arial, sans-serif',
+      fontWeight: 400,
     },
   },
 });


### PR DESCRIPTION
## Summary
- define Tailwind font tokens for Fredoka headings and Glacial Indifference body text and wire them through the MUI theme and global styles
- replace the handcrafted SVG in `LearningStyleOverview` with the Material UI PieChart, preserving hover details and aligning text styling
- add the @mui/x-charts dependency required for the new chart implementation

## Testing
- ⚠️ `npm install @mui/x-charts@^7.22.2` *(fails: npm registry access returned 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fc901ca88332986424d936b6e41f