### PR TITLE
Align thread map flow node data with database schema

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -1,11 +1,15 @@
 import React, { useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 
-import type { NodeData } from "./types";
+import type { DatabaseNode } from "./types";
 import { nodeModules } from "./mockData";
 
+type ConceptNodeData = DatabaseNode & {
+  color?: string;
+};
+
 interface ConceptNodeProps {
-  data: NodeData;
+  data: ConceptNodeData;
   selected?: boolean;
 }
 
@@ -13,11 +17,11 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   data,
   selected = false,
 }) => {
-  const size = data.node_type === "topic" ? 120 : 80;
-  const fontSize = data.node_type === "topic" ? "16px" : "14px";
+  const size = data.type === "topic" ? 120 : 80;
+  const fontSize = data.type === "topic" ? "16px" : "14px";
 
   const moduleInfo = nodeModules.find(
-    (m) => m.module_id === data.node_module_id
+    (m) => m.module_id === data.module_id
   );
   const moduleNumber = moduleInfo?.module_id;
 
@@ -90,8 +94,8 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     textAlign: "center",
     color: "#1f2937",
     fontFamily: '"Fredoka", sans-serif',
-    fontWeight: data.node_type === "topic" ? 700 : 600,
-    fontSize: data.node_type === "topic" ? "16px" : "13px",
+    fontWeight: data.type === "topic" ? 700 : 600,
+    fontSize: data.type === "topic" ? "16px" : "13px",
     lineHeight: 1.25,
     maxWidth: circleSize,
     wordBreak: "normal", // Avoid breaking words
@@ -132,11 +136,9 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           position: "relative",
           overflow: "hidden",
         }}
-        title={`${data.node_name}${
-          data.node_description
-            ? "\n Description: " + data.node_description
-            : ""
-        }\nModule: ${moduleInfo?.module_name || data.node_module_id}`}
+        title={`${data.name}${
+          data.summary ? "\n Description: " + data.summary : ""
+        }\nModule: ${moduleInfo?.module_name || data.module_id}`}
       >
         <div
           style={{
@@ -150,7 +152,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
         >
           <div
             style={{
-              fontSize: data.node_type === "topic" ? "24px" : "18px",
+              fontSize: data.type === "topic" ? "24px" : "18px",
               fontWeight: 700,
             }}
           >
@@ -159,7 +161,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
 
           <div
             style={{
-              fontSize: data.node_type === "topic" ? "11px" : "10px",
+              fontSize: data.type === "topic" ? "11px" : "10px",
               lineHeight: "1.2",
               maxWidth: "90%",
               overflow: "hidden",
@@ -259,7 +261,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           "+"
         )}
       </div>
-      <div style={nameStyles}>{data.node_name}</div>
+      <div style={nameStyles}>{data.name}</div>
     </div>
   );
 };

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -5,8 +5,15 @@ import {
   getStraightPath,
   useReactFlow,
 } from "@xyflow/react";
-import type { EdgeProps, XYPosition } from "@xyflow/react";
-import type { FlowEdge, FlowNode } from "./types";
+import type { Edge, EdgeProps, Node, XYPosition } from "@xyflow/react";
+import type { DatabaseNode } from "./types";
+
+type ThreadMapNodeData = DatabaseNode & {
+  color?: string;
+};
+
+type ThreadMapFlowNode = Node<ThreadMapNodeData>;
+type ThreadMapFlowEdge = Edge;
 
 const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   const {
@@ -22,13 +29,16 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     data,
   } = props;
 
-  const { getEdges, getNode } = useReactFlow<FlowNode, FlowEdge>();
+  const { getEdges, getNode } = useReactFlow<
+    ThreadMapFlowNode,
+    ThreadMapFlowEdge
+  >();
   const edges = getEdges();
 
   const sourceNode = getNode(source);
   const targetNode = getNode(target);
 
-  type ExtendedNode = FlowNode & {
+  type ExtendedNode = ThreadMapFlowNode & {
     width?: number | null;
     height?: number | null;
     position?: XYPosition;
@@ -39,7 +49,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     };
   };
 
-  const getNodeMetrics = (node?: FlowNode | null) => {
+  const getNodeMetrics = (node?: ThreadMapFlowNode | null) => {
     if (!node) {
       return null;
     }


### PR DESCRIPTION
## Summary
- align thread map React Flow node typing with the database node schema while preserving database structures
- update ConceptNode and HoverLabelEdge components to consume the database-aligned node data shape and color metadata

## Testing
- npm run build *(fails: existing TypeScript errors outside the modified files)*

------
https://chatgpt.com/codex/tasks/task_e_68d99eb5684883328a2f204b3a7c44d0