### PR TITLE
Load thread map metadata from API

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -1,14 +1,10 @@
 import React, { useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 
-import type { DatabaseNode } from "./types";
-
-type ConceptNodeData = DatabaseNode & {
-  color?: string;
-};
+import type { NodeData } from "./types";
 
 interface ConceptNodeProps {
-  data: ConceptNodeData;
+  data: NodeData;
   selected?: boolean;
 }
 
@@ -16,11 +12,10 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   data,
   selected = false,
 }) => {
-  const size = data.type === "topic" ? 120 : 80;
-  const fontSize = data.type === "topic" ? "16px" : "14px";
+  const size = data.node_type === "topic" ? 120 : 80;
+  const fontSize = data.node_type === "topic" ? "16px" : "14px";
 
-  const moduleInfo = nodeModules.find((m) => m.module_id === data.module_id);
-  const moduleNumber = moduleInfo?.module_id;
+  const moduleNumber = data.node_module_index ?? data.node_module_id;
 
   // State to track which handle is hovered
   const [hoveredHandle, setHoveredHandle] = useState<string | null>(null);
@@ -91,8 +86,8 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     textAlign: "center",
     color: "#1f2937",
     fontFamily: '"Fredoka", sans-serif',
-    fontWeight: data.type === "topic" ? 700 : 600,
-    fontSize: data.type === "topic" ? "16px" : "13px",
+    fontWeight: data.node_type === "topic" ? 700 : 600,
+    fontSize: data.node_type === "topic" ? "16px" : "13px",
     lineHeight: 1.25,
     maxWidth: circleSize,
     wordBreak: "normal", // Avoid breaking words
@@ -133,9 +128,11 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           position: "relative",
           overflow: "hidden",
         }}
-        title={`${data.name}${
-          data.summary ? "\n Description: " + data.summary : ""
-        }\nModule: ${moduleInfo?.module_name || data.module_id}`}
+        title={`${data.node_name}${
+          data.node_description
+            ? "\n Description: " + data.node_description
+            : ""
+        }\nModule: ${data.node_module_name || data.node_module_id}`}
       >
         <div
           style={{
@@ -149,7 +146,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
         >
           <div
             style={{
-              fontSize: data.type === "topic" ? "24px" : "18px",
+              fontSize: data.node_type === "topic" ? "24px" : "18px",
               fontWeight: 700,
             }}
           >
@@ -158,7 +155,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
 
           <div
             style={{
-              fontSize: data.type === "topic" ? "11px" : "10px",
+              fontSize: data.node_type === "topic" ? "11px" : "10px",
               lineHeight: "1.2",
               maxWidth: "90%",
               overflow: "hidden",
@@ -258,7 +255,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           "+"
         )}
       </div>
-      <div style={nameStyles}>{data.name}</div>
+      <div style={nameStyles}>{data.node_name}</div>
     </div>
   );
 };

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/colorUtils.ts
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/colorUtils.ts
@@ -1,29 +1,41 @@
-export const getColorForModule = (moduleId: string): string => {
-  const module = nodeModules.find((m) => m.module_id === moduleId);
-  if (module) return module.color;
+import type { NodeModule } from "./types";
 
-  const colors = [
-    "#00bcd4",
-    "#5c9cfc",
-    "#4a85f5",
-    "#ff6b35",
-    "#4caf50",
-    "#9c27b0",
-    "#ff9800",
-    "#e91e63",
-  ];
-  const hash = moduleId.split("").reduce((a, b) => {
-    a = (a << 5) - a + b.charCodeAt(0);
-    return a & a;
+const MODULE_COLORS = [
+  "#00bcd4",
+  "#5c9cfc",
+  "#4a85f5",
+  "#ff6b35",
+  "#4caf50",
+  "#9c27b0",
+  "#ff9800",
+  "#e91e63",
+];
+
+const computeColorFromId = (seed: string): string => {
+  const hash = seed.split("").reduce((acc, char) => {
+    acc = (acc << 5) - acc + char.charCodeAt(0);
+    return acc & acc;
   }, 0);
-  return colors[Math.abs(hash) % colors.length];
+  return MODULE_COLORS[Math.abs(hash) % MODULE_COLORS.length];
+};
+
+export const getColorForModule = (
+  moduleId: string,
+  modules: Record<string, NodeModule | undefined>
+): string => {
+  const module = modules[moduleId];
+  if (module?.color) {
+    return module.color;
+  }
+
+  return computeColorFromId(moduleId);
 };
 
 export const getTopicColor = (moduleColor: string): string => {
   const hex = moduleColor.replace("#", "");
   const r = Math.max(0, parseInt(hex.substring(0, 2), 16) - 20);
-  const g = Math.max(0, parseInt(hex.substring(2, 2), 16) - 20);
-  const b = Math.max(0, parseInt(hex.substring(4, 2), 16) - 20);
+  const g = Math.max(0, parseInt(hex.substring(2, 4), 16) - 20);
+  const b = Math.max(0, parseInt(hex.substring(4, 6), 16) - 20);
   return `#${r.toString(16).padStart(2, "0")}${g
     .toString(16)
     .padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
@@ -76,19 +88,10 @@ const hslToHex = (h: number, s: number, l: number): string => {
   return `#${r}${g}${b}`;
 };
 
-export const generateDistinctTopicColor = (usedColors: Set<string>): string => {
-  const basePalette = [
-    "#00bcd4",
-    "#5c9cfc",
-    "#4a85f5",
-    "#ff6b35",
-    "#4caf50",
-    "#9c27b0",
-    "#ff9800",
-    "#e91e63",
-  ];
-
-  for (const color of basePalette) {
+export const generateDistinctTopicColor = (
+  usedColors: Set<string>
+): string => {
+  for (const color of MODULE_COLORS) {
     if (!usedColors.has(color)) {
       return color;
     }

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/types.ts
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/types.ts
@@ -7,6 +7,8 @@ export interface NodeData extends Record<string, unknown> {
   node_type: "topic" | "concept";
   parent_node_id?: string;
   node_module_id: string;
+  node_module_name?: string;
+  node_module_index?: string;
   color?: string;
 }
 
@@ -37,6 +39,7 @@ export interface HoverNode {
 
 export interface NodeModule {
   module_id: string;
-  module_name: string;
+  module_name?: string;
+  module_index?: string;
   color: string;
 }


### PR DESCRIPTION
## Summary
- fetch thread map module metadata alongside nodes and relationships so module names, indices, and colors come from the backend
- populate node data with module context for ConceptNode rendering and feed available modules into the add-node modal
- replace hardcoded color helpers with lookup-aware utilities that derive colors from database identifiers

## Testing
- npm run build *(fails: frontend package does not define a build script)*

------
https://chatgpt.com/codex/tasks/task_e_68d9b1bf0bf08332b2e27ca9e7cb1fde