### PR TITLE
Fix thread map type issues

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
@@ -823,8 +823,13 @@ const ThreadMap: React.FC<{ module_id: string }> = ({ module_id }) => {
     (params) => {
       if (!params.source || !params.target) return;
 
+      const maxRelationshipId = dbRelationships.reduce((max, relationship) => {
+        const numericId = Number(relationship.id);
+        return Number.isFinite(numericId) ? Math.max(max, numericId) : max;
+      }, 0);
+
       const newRelationship: DatabaseRelationship = {
-        id: Math.max(...dbRelationships.map((r) => r.id), 0) + 1,
+        id: String(maxRelationshipId + 1),
         first_node: params.source,
         second_node: params.target,
         rs_type: "",

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -5,15 +5,8 @@ import {
   getStraightPath,
   useReactFlow,
 } from "@xyflow/react";
-import type { Edge, EdgeProps, Node, XYPosition } from "@xyflow/react";
-import type { DatabaseNode } from "./types";
-
-type ThreadMapNodeData = DatabaseNode & {
-  color?: string;
-};
-
-type ThreadMapFlowNode = Node<ThreadMapNodeData>;
-type ThreadMapFlowEdge = Edge;
+import type { EdgeProps, XYPosition } from "@xyflow/react";
+import type { FlowEdge, FlowNode } from "./types";
 
 const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   const {
@@ -29,16 +22,13 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     data,
   } = props;
 
-  const { getEdges, getNode } = useReactFlow<
-    ThreadMapFlowNode,
-    ThreadMapFlowEdge
-  >();
+  const { getEdges, getNode } = useReactFlow<FlowNode, FlowEdge>();
   const edges = getEdges();
 
   const sourceNode = getNode(source);
   const targetNode = getNode(target);
 
-  type ExtendedNode = ThreadMapFlowNode & {
+  type ExtendedNode = FlowNode & {
     width?: number | null;
     height?: number | null;
     position?: XYPosition;
@@ -49,7 +39,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     };
   };
 
-  const getNodeMetrics = (node?: ThreadMapFlowNode | null) => {
+  const getNodeMetrics = (node?: FlowNode | null) => {
     if (!node) {
       return null;
     }


### PR DESCRIPTION
## Summary
- ensure new relationships created in the thread map receive numeric string identifiers
- align hover label edge React Flow generics with the existing flow node and edge types

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d9b83eed40833292046fbee45dba79