### PR TITLE
Improve thread map layout and controls

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -12,8 +12,8 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   data,
   selected = false,
 }) => {
-  const size = data.node_type === "topic" ? 120 : 80;
-  const fontSize = data.node_type === "topic" ? "16px" : "14px";
+  const size = data.node_type === "topic" ? 120 : 68;
+  const fontSize = data.node_type === "topic" ? "16px" : "12px";
 
   const moduleNumber = data.node_module_index ?? data.node_module_id;
 
@@ -87,7 +87,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     color: "#1f2937",
     fontFamily: '"Fredoka", sans-serif',
     fontWeight: data.node_type === "topic" ? 700 : 600,
-    fontSize: data.node_type === "topic" ? "16px" : "13px",
+    fontSize: data.node_type === "topic" ? "16px" : "12px",
     lineHeight: 1.25,
     maxWidth: circleSize,
     wordBreak: "normal", // Avoid breaking words
@@ -146,7 +146,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
         >
           <div
             style={{
-              fontSize: data.node_type === "topic" ? "24px" : "18px",
+              fontSize: data.node_type === "topic" ? "24px" : "16px",
               fontWeight: 700,
             }}
           >
@@ -155,7 +155,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
 
           <div
             style={{
-              fontSize: data.node_type === "topic" ? "11px" : "10px",
+              fontSize: data.node_type === "topic" ? "11px" : "9px",
               lineHeight: "1.2",
               maxWidth: "90%",
               overflow: "hidden",

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -2,7 +2,8 @@ import React, { useMemo, useState } from "react";
 import {
   BaseEdge,
   EdgeLabelRenderer,
-  getStraightPath,
+  getBezierPath,
+  Position,
   useReactFlow,
 } from "@xyflow/react";
 import type { EdgeProps, XYPosition } from "@xyflow/react";
@@ -114,7 +115,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   );
 
   const parallelIndex = parallelEdges.findIndex((edge) => edge.id === id);
-  const offsetStep = 18;
+  const offsetStep = 26;
   const offsetAmount =
     parallelEdges.length > 1
       ? (parallelIndex - (parallelEdges.length - 1) / 2) * offsetStep
@@ -127,11 +128,32 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   const offsetX = (-dy / length) * offsetAmount;
   const offsetY = (dx / length) * offsetAmount;
 
-  const [edgePath, labelX, labelY] = getStraightPath({
+  const dominantAxisIsHorizontal = Math.abs(dx) >= Math.abs(dy);
+  const sourcePosition = dominantAxisIsHorizontal
+    ? dx >= 0
+      ? Position.Right
+      : Position.Left
+    : dy >= 0
+    ? Position.Bottom
+    : Position.Top;
+  const targetPosition = dominantAxisIsHorizontal
+    ? dx >= 0
+      ? Position.Left
+      : Position.Right
+    : dy >= 0
+    ? Position.Top
+    : Position.Bottom;
+
+  const curvature = Math.min(0.6, 0.35 + Math.abs(offsetAmount) / 160);
+
+  const [edgePath, labelX, labelY] = getBezierPath({
     sourceX: rawSourcePoint.x + offsetX,
     sourceY: rawSourcePoint.y + offsetY,
+    sourcePosition,
     targetX: rawTargetPoint.x + offsetX,
     targetY: rawTargetPoint.y + offsetY,
+    targetPosition,
+    curvature,
   });
 
   const [isHovered, setIsHovered] = useState(false);


### PR DESCRIPTION
## Summary
- collapse the thread map controls into a draggable toggle with a compact floating panel
- retune the D3 layout and edge rendering so concepts cluster with their topics while keeping clusters farther apart
- shrink concept node visuals to emphasize topics and reduce edge overlap

## Testing
- npm run lint *(fails: cannot find package '@eslint/js' from eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68dabb2e91188332a9b16124c87b29d4