### PR TITLE
Improve ThreadMap layout and controls

### DIFF
--- a/nala/frontend/nalaLearnscape/src/App.tsx
+++ b/nala/frontend/nalaLearnscape/src/App.tsx
@@ -13,7 +13,7 @@ function App() {
         <Route path="/" element={<Home />} />
         <Route path="/Modules" element={<Modules />} />
         <Route path="/Modules/:moduleId" element={<ModuleInfo />} />
-        {/* <Route path="/threadmap" element={<ThreadMap />} /> */}
+        <Route path="/threadmap" element={<ThreadMap />} />
         <Route path="/Modules/:moduleId/Topics/:topicId/Notes" element={<KnowledgeCapsule />} />
       </Routes>
     </Router>

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -16,6 +16,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   const fontSize = data.node_type === "topic" ? "16px" : "12px";
 
   const moduleNumber = data.node_module_index ?? data.node_module_id;
+  const showModuleBadge = data.node_type === "topic";
 
   // State to track which handle is hovered
   const [hoveredHandle, setHoveredHandle] = useState<string | null>(null);
@@ -134,38 +135,27 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
             : ""
         }\nModule: ${data.node_module_name || data.node_module_id}`}
       >
-        <div
-          style={{
-            padding: "12px 10px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: "100%",
-            height: "100%",
-          }}
-        >
+        {showModuleBadge && (
           <div
             style={{
-              fontSize: data.node_type === "topic" ? "24px" : "16px",
-              fontWeight: 700,
+              padding: "12px 10px",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "100%",
+              height: "100%",
             }}
           >
-            {moduleNumber || "?"}
+            <div
+              style={{
+                fontSize: "24px",
+                fontWeight: 700,
+              }}
+            >
+              {moduleNumber || "?"}
+            </div>
           </div>
-
-          <div
-            style={{
-              fontSize: data.node_type === "topic" ? "11px" : "9px",
-              lineHeight: "1.2",
-              maxWidth: "90%",
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
-            }}
-          ></div>
-        </div>
+        )}
         {renderHandle(
           "target-top",
           "target",


### PR DESCRIPTION
## Summary
- resolve the ThreadMap module ID from query parameters, expose the standalone /threadmap route, and keep the layout centered without manual dragging
- add dynamic controls, safer hover placement, and a full-view launcher so nodes/edges stay visible and controls are more intuitive
- render concept nodes as empty circles to match the desired visual style

## Testing
- npm run lint *(fails: missing @eslint/js dependency in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dac8a8ed6883329197904fcbf0e076