### PR TITLE
Refine thread map controls and dragging

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -1,11 +1,5 @@
 import React, { useMemo, useState } from "react";
-import {
-  BaseEdge,
-  EdgeLabelRenderer,
-  getBezierPath,
-  Position,
-  useReactFlow,
-} from "@xyflow/react";
+import { BaseEdge, EdgeLabelRenderer, useReactFlow } from "@xyflow/react";
 import type { EdgeProps, XYPosition } from "@xyflow/react";
 import type { FlowEdge, FlowNode } from "./types";
 
@@ -111,7 +105,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
           (edge.source === source && edge.target === target) ||
           (edge.source === target && edge.target === source)
       ),
-    [edges, source, target, sourceX, sourceY, targetX, targetY]
+    [edges, source, target]
   );
 
   const parallelIndex = parallelEdges.findIndex((edge) => edge.id === id);
@@ -128,33 +122,18 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   const offsetX = (-dy / length) * offsetAmount;
   const offsetY = (dx / length) * offsetAmount;
 
-  const dominantAxisIsHorizontal = Math.abs(dx) >= Math.abs(dy);
-  const sourcePosition = dominantAxisIsHorizontal
-    ? dx >= 0
-      ? Position.Right
-      : Position.Left
-    : dy >= 0
-    ? Position.Bottom
-    : Position.Top;
-  const targetPosition = dominantAxisIsHorizontal
-    ? dx >= 0
-      ? Position.Left
-      : Position.Right
-    : dy >= 0
-    ? Position.Top
-    : Position.Bottom;
+  const startPoint = {
+    x: rawSourcePoint.x + offsetX,
+    y: rawSourcePoint.y + offsetY,
+  };
+  const endPoint = {
+    x: rawTargetPoint.x + offsetX,
+    y: rawTargetPoint.y + offsetY,
+  };
 
-  const curvature = Math.min(0.6, 0.35 + Math.abs(offsetAmount) / 160);
-
-  const [edgePath, labelX, labelY] = getBezierPath({
-    sourceX: rawSourcePoint.x + offsetX,
-    sourceY: rawSourcePoint.y + offsetY,
-    sourcePosition,
-    targetX: rawTargetPoint.x + offsetX,
-    targetY: rawTargetPoint.y + offsetY,
-    targetPosition,
-    curvature,
-  });
+  const edgePath = `M ${startPoint.x},${startPoint.y} L ${endPoint.x},${endPoint.y}`;
+  const labelX = (startPoint.x + endPoint.x) / 2;
+  const labelY = (startPoint.y + endPoint.y) / 2;
 
   const [isHovered, setIsHovered] = useState(false);
 

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/controlPanelState.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/controlPanelState.tsx
@@ -1,0 +1,57 @@
+import { Info, Plus, Trash2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+type ControlPanelState = {
+  Icon: LucideIcon;
+  color: string;
+  shadow: string;
+  label: string;
+  deleteLabel?: string;
+};
+
+export type ControlMode = "info" | "edge" | "delete-node" | "delete-edge";
+
+const CONTROL_MAP: Record<ControlMode, ControlPanelState> = {
+  info: {
+    Icon: Info,
+    color: "#1f2937",
+    shadow: "0 12px 26px rgba(15, 23, 42, 0.35)",
+    label: "Threadmap information",
+  },
+  edge: {
+    Icon: Plus,
+    color: "#2563eb",
+    shadow: "0 12px 26px rgba(37, 99, 235, 0.45)",
+    label: "Edge creation in progress (click to cancel)",
+  },
+  "delete-node": {
+    Icon: Trash2,
+    color: "#ef4444",
+    shadow: "0 12px 26px rgba(239, 68, 68, 0.45)",
+    label: "Delete selected node",
+    deleteLabel: "Delete Selected Node",
+  },
+  "delete-edge": {
+    Icon: Trash2,
+    color: "#ef4444",
+    shadow: "0 12px 26px rgba(239, 68, 68, 0.45)",
+    label: "Delete selected edge",
+    deleteLabel: "Delete Selected Edge",
+  },
+};
+
+export const getControlMode = (
+  selectedNode: string | null,
+  selectedEdge: string | null,
+  isAddingEdge: boolean
+): ControlMode => {
+  if (isAddingEdge) return "edge";
+  if (selectedNode) return "delete-node";
+  if (selectedEdge) return "delete-edge";
+  return "info";
+};
+
+export const getControlPanelState = (
+  mode: ControlMode
+): ControlPanelState => CONTROL_MAP[mode];
+


### PR DESCRIPTION
## Summary
- streamline control panel rendering by centralizing icon/label metadata
- loosen node dragging sensitivity while keeping pointer/add-node mode toggle responsive
- ensure quick tips display on hover and maintain delete actions for selected nodes or edges

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dad6a337008332b76c7bb8acf2e4e2