### PR TITLE
Improve threadmap layout and controls

### DIFF
--- a/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
@@ -245,14 +245,25 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
   }, []);
 
   useEffect(() => {
-    if (passedModule && rawData.length > 0) {
-      // If the module exists in data, select + expand it
-      if (moduleData[passedModule]) {
-        setSelectedModule(passedModule);
-        setExpandedModule(passedModule);
-      }
+    if (!passedModule || rawData.length === 0) {
+      return;
     }
-  }, [passedModule, rawData, moduleData]);
+
+    const normalized = passedModule.toString().trim().toLowerCase();
+    if (!normalized) {
+      return;
+    }
+
+    const matchedModule =
+      modules.find((module) => module.toLowerCase() === normalized) ||
+      modules.find((module) => module.toLowerCase().includes(normalized)) ||
+      modules.find((module) => normalized.includes(module.toLowerCase()));
+
+    if (matchedModule) {
+      setSelectedModule(matchedModule);
+      setExpandedModule(matchedModule);
+    }
+  }, [modules, passedModule, rawData]);
 
   return (
     <div

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -12,11 +12,12 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   data,
   selected = false,
 }) => {
-  const size = data.node_type === "topic" ? 120 : 68;
-  const fontSize = data.node_type === "topic" ? "16px" : "12px";
+  const isTopic = data.node_type === "topic";
+  const size = isTopic ? 120 : 68;
+  const fontSize = isTopic ? "16px" : "12px";
 
   const moduleNumber = data.node_module_index ?? data.node_module_id;
-  const showModuleBadge = data.node_type === "topic";
+  const showModuleBadge = isTopic;
 
   // State to track which handle is hovered
   const [hoveredHandle, setHoveredHandle] = useState<string | null>(null);
@@ -82,18 +83,41 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   );
 
   const circleSize = `${size}px`;
-  const nameStyles: React.CSSProperties = {
+  const topicNameStyles: React.CSSProperties = {
     marginTop: "10px",
     textAlign: "center",
     color: "#1f2937",
     fontFamily: '"Fredoka", sans-serif',
-    fontWeight: data.node_type === "topic" ? 700 : 600,
-    fontSize: data.node_type === "topic" ? "16px" : "12px",
+    fontWeight: isTopic ? 700 : 600,
+    fontSize: isTopic ? "16px" : "12px",
     lineHeight: 1.25,
     maxWidth: circleSize,
     wordBreak: "normal", // Avoid breaking words
     overflowWrap: "break-word", // Allow wrapping of long words when necessary
     whiteSpace: "normal", // Allow text to wrap to the next line if needed
+  };
+  const conceptLabelContainerStyles: React.CSSProperties = {
+    width: "100%",
+    height: "100%",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    padding: "12px",
+    color: "#ffffff",
+    fontFamily: '"GlacialIndifference", sans-serif',
+    fontWeight: 600,
+    fontSize: "12px",
+    lineHeight: 1.3,
+    textAlign: "center",
+    pointerEvents: "none",
+  };
+  const conceptLabelTextStyles: React.CSSProperties = {
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    display: "-webkit-box",
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: "vertical",
+    width: "100%",
   };
 
   return (
@@ -128,6 +152,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           boxSizing: "border-box",
           position: "relative",
           overflow: "hidden",
+          padding: 0,
         }}
         title={`${data.node_name}${
           data.node_description
@@ -135,7 +160,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
             : ""
         }\nModule: ${data.node_module_name || data.node_module_id}`}
       >
-        {showModuleBadge && (
+        {showModuleBadge ? (
           <div
             style={{
               padding: "12px 10px",
@@ -154,6 +179,10 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
             >
               {moduleNumber || "?"}
             </div>
+          </div>
+        ) : (
+          <div style={conceptLabelContainerStyles} title={data.node_name}>
+            <span style={conceptLabelTextStyles}>{data.node_name}</span>
           </div>
         )}
         {renderHandle(
@@ -245,7 +274,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           "+"
         )}
       </div>
-      <div style={nameStyles}>{data.node_name}</div>
+      {isTopic && <div style={topicNameStyles}>{data.node_name}</div>}
     </div>
   );
 };

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from "react";
 import { BaseEdge, EdgeLabelRenderer, useReactFlow } from "@xyflow/react";
 import type { EdgeProps, XYPosition } from "@xyflow/react";
-import type { FlowEdge, FlowNode } from "./types";
+import type { FlowEdge, FlowNode, NodeData } from "./types";
 
 const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
   const {
@@ -51,7 +51,15 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
 
     const centerX = position.x + width / 2;
     const centerY = position.y + height / 2;
-    const radius = Math.min(width, height) / 2;
+    const nodeData = (extended.data ?? null) as NodeData | null;
+    const measuredRadius = Math.min(width, height) / 2;
+    let radius = measuredRadius;
+
+    if (nodeData?.node_type === "topic") {
+      radius = Math.max(measuredRadius, 60);
+    } else if (nodeData?.node_type === "concept") {
+      radius = Math.max(measuredRadius, 34);
+    }
 
     return { centerX, centerY, radius };
   };


### PR DESCRIPTION
## Summary
- align the topic taxonomy with the active threadmap module in full view and surface the selection in the UI
- refine concept node visuals and edge rendering, including a toggle for concept-parent edges and an edit-mode delete affordance
- retune the force-directed layout for cleaner spacing while keeping React Flow integration intact

## Testing
- npm run lint *(fails: cannot find @eslint/js due to missing optional dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68db9faae6908332aba62e216bdbf887