### PR TITLE
Improve thread map layout and taxonomy display

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Handle, Position } from "@xyflow/react";
 
+import { CONCEPT_NODE_DIAMETER, TOPIC_NODE_DIAMETER } from "./constants";
 import type { NodeData } from "./types";
 
 interface ConceptNodeProps {
@@ -13,8 +14,8 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
   selected = false,
 }) => {
   const isTopic = data.node_type === "topic";
-  const size = isTopic ? 120 : 68;
-  const fontSize = isTopic ? "16px" : "12px";
+  const diameter = isTopic ? TOPIC_NODE_DIAMETER : CONCEPT_NODE_DIAMETER;
+  const fontSize = isTopic ? "18px" : "14px";
 
   const moduleNumber = data.node_module_index ?? data.node_module_id;
   const showModuleBadge = isTopic;
@@ -82,15 +83,15 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     </React.Fragment>
   );
 
-  const circleSize = `${size}px`;
+  const circleSize = `${diameter}px`;
   const topicNameStyles: React.CSSProperties = {
     marginTop: "10px",
     textAlign: "center",
     color: "#1f2937",
     fontFamily: '"Fredoka", sans-serif',
     fontWeight: isTopic ? 700 : 600,
-    fontSize: isTopic ? "16px" : "12px",
-    lineHeight: 1.25,
+    fontSize: isTopic ? "20px" : "14px",
+    lineHeight: 1.3,
     maxWidth: circleSize,
     wordBreak: "normal", // Avoid breaking words
     overflowWrap: "break-word", // Allow wrapping of long words when necessary
@@ -102,12 +103,12 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    padding: "12px",
+    padding: "16px",
     color: "#ffffff",
     fontFamily: '"GlacialIndifference", sans-serif',
     fontWeight: 600,
-    fontSize: "12px",
-    lineHeight: 1.3,
+    fontSize: "14px",
+    lineHeight: 1.35,
     textAlign: "center",
     pointerEvents: "none",
   };
@@ -115,7 +116,7 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
     overflow: "hidden",
     textOverflow: "ellipsis",
     display: "-webkit-box",
-    WebkitLineClamp: 3,
+    WebkitLineClamp: 4,
     WebkitBoxOrient: "vertical",
     width: "100%",
   };

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -1,6 +1,8 @@
 import React, { useMemo, useState } from "react";
 import { BaseEdge, EdgeLabelRenderer, useReactFlow } from "@xyflow/react";
 import type { EdgeProps, XYPosition } from "@xyflow/react";
+
+import { CONCEPT_BASE_RADIUS, TOPIC_BASE_RADIUS } from "./constants";
 import type { FlowEdge, FlowNode, NodeData } from "./types";
 
 const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
@@ -53,13 +55,11 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     const centerY = position.y + height / 2;
     const nodeData = (extended.data ?? null) as NodeData | null;
     const measuredRadius = Math.min(width, height) / 2;
-    let radius = measuredRadius;
-
-    if (nodeData?.node_type === "topic") {
-      radius = Math.max(measuredRadius, 60);
-    } else if (nodeData?.node_type === "concept") {
-      radius = Math.max(measuredRadius, 34);
-    }
+    const fallbackRadius =
+      nodeData?.node_type === "topic"
+        ? TOPIC_BASE_RADIUS
+        : CONCEPT_BASE_RADIUS;
+    const radius = Math.max(measuredRadius, fallbackRadius);
 
     return { centerX, centerY, radius };
   };

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/constants.ts
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/constants.ts
@@ -1,0 +1,8 @@
+export const TOPIC_BASE_RADIUS = 84;
+export const CONCEPT_BASE_RADIUS = 52;
+
+export const TOPIC_NODE_DIAMETER = TOPIC_BASE_RADIUS * 2;
+export const CONCEPT_NODE_DIAMETER = CONCEPT_BASE_RADIUS * 2;
+
+export const CLUSTER_GAP = 72;
+export const CLUSTER_MAX_OFFSET = 260;

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/layoutUtils.ts
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/layoutUtils.ts
@@ -1,7 +1,5 @@
+import { CONCEPT_BASE_RADIUS, TOPIC_BASE_RADIUS } from "./constants";
 import type { FlowNode } from "./types";
-
-const TOPIC_BASE_RADIUS = 120;
-const CONCEPT_BASE_RADIUS = 72;
 
 export const getNodeRadius = (node: FlowNode): number => {
   const type = node.data?.node_type;


### PR DESCRIPTION
## Summary
- recentre thread map clusters after node drags by re-running the layout with shared layout constants
- enlarge topic and concept node rendering, adjust edge anchors, and share geometry constants between components
- surface the active module label in the taxonomy panel and update edit controls to use pencil and delete icons

## Testing
- npm run build *(fails: existing missing type declarations and unrelated TypeScript errors in other components)*

------
https://chatgpt.com/codex/tasks/task_e_68dbab95fe188332bf47d6e5abea39f3