### PR TITLE
Improve thread map layout and taxonomy interactions

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/ConceptNode.tsx
@@ -145,8 +145,12 @@ const ConceptNode: React.FC<ConceptNodeProps> = ({
           cursor: "pointer",
           borderStyle: "solid",
           borderWidth: 3,
-          borderColor: selected ? "#ff6b35" : "rgba(255,255,255,0.35)",
-          transition: "box-shadow 0.2s ease, border-color 0.2s ease",
+          borderColor: selected ? "#ef4444" : "rgba(255,255,255,0.35)",
+          transition:
+            "box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease",
+          boxShadow: selected
+            ? "0 0 0 3px rgba(239, 68, 68, 0.45), 0 16px 30px rgba(15, 23, 42, 0.22)"
+            : "0 12px 22px rgba(15, 23, 42, 0.12)",
           boxSizing: "border-box",
           position: "relative",
           overflow: "hidden",


### PR DESCRIPTION
## Summary
- memoize module data in the taxonomy widget and support numeric module identifiers when choosing the initial module
- refine the thread map force simulation to prevent node overlap, keep selection stable, and highlight the chosen node/edge with a red glow
- keep the delete control available in edit mode and allow the taxonomy panel to be dragged across the full view without restricting edge lengths within topic clusters

## Testing
- npm run lint *(fails: missing optional dependency @eslint/js in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb2a9e08c8332acf7032eeca2571c