### PR TITLE
Enhance thread map interactions

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/EdgeInputModal.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/EdgeInputModal.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import type { DatabaseNode } from "./types";
+
+interface EdgeInputModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (firstNodeId: string, secondNodeId: string, relationshipType: string) => void;
+  availableNodes: DatabaseNode[];
+  initialFirstNodeId?: string;
+  initialSecondNodeId?: string;
+  initialRelationshipType?: string;
+}
+
+const EdgeInputModal: React.FC<EdgeInputModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  availableNodes,
+  initialFirstNodeId,
+  initialSecondNodeId,
+  initialRelationshipType = "",
+}) => {
+  const [firstNodeId, setFirstNodeId] = useState<string>("");
+  const [secondNodeId, setSecondNodeId] = useState<string>("");
+  const [relationshipType, setRelationshipType] = useState<string>("");
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    setFirstNodeId(initialFirstNodeId ?? "");
+    setSecondNodeId(initialSecondNodeId ?? "");
+    setRelationshipType(initialRelationshipType ?? "");
+  }, [
+    initialFirstNodeId,
+    initialRelationshipType,
+    initialSecondNodeId,
+    isOpen,
+  ]);
+
+  const sortedNodes = useMemo(
+    () =>
+      [...availableNodes].sort((a, b) => a.name.localeCompare(b.name, undefined, {
+        sensitivity: "base",
+      })),
+    [availableNodes]
+  );
+
+  const handleSave = () => {
+    const trimmedType = relationshipType.trim();
+    const sourceId = firstNodeId.trim();
+    const targetId = secondNodeId.trim();
+
+    if (!sourceId || !targetId || sourceId === targetId) {
+      return;
+    }
+
+    onSave(sourceId, targetId, trimmedType);
+  };
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: "rgba(15, 23, 42, 0.45)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 2100,
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          backgroundColor: "#fff",
+          padding: "24px",
+          borderRadius: "12px",
+          boxShadow: "0 18px 45px rgba(15, 23, 42, 0.35)",
+          minWidth: "420px",
+          maxWidth: "92vw",
+          maxHeight: "80vh",
+          overflowY: "auto",
+          fontFamily: "'GlacialIndifference', sans-serif",
+          color: "#0f172a",
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h3 style={{ margin: 0, fontSize: "18px", fontWeight: 700 }}>
+          Add New Relationship
+        </h3>
+        <p style={{ marginTop: "8px", fontSize: "12.5px", color: "#64748b" }}>
+          Define the nodes you want to connect and the relationship type.
+        </p>
+
+        <div style={{ marginTop: "16px" }}>
+          <label
+            style={{
+              display: "block",
+              marginBottom: "6px",
+              fontSize: "13px",
+              fontWeight: 600,
+            }}
+          >
+            First node *
+          </label>
+          <select
+            value={firstNodeId}
+            onChange={(event) => setFirstNodeId(event.target.value)}
+            style={{
+              width: "100%",
+              padding: "12px",
+              borderRadius: "8px",
+              border: "1px solid #cbd5f5",
+              fontSize: "14px",
+            }}
+          >
+            <option value="">Select a node</option>
+            {sortedNodes.map((node) => (
+              <option key={node.id} value={node.id}>
+                {node.name}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div style={{ marginTop: "16px" }}>
+          <label
+            style={{
+              display: "block",
+              marginBottom: "6px",
+              fontSize: "13px",
+              fontWeight: 600,
+            }}
+          >
+            Second node *
+          </label>
+          <select
+            value={secondNodeId}
+            onChange={(event) => setSecondNodeId(event.target.value)}
+            style={{
+              width: "100%",
+              padding: "12px",
+              borderRadius: "8px",
+              border: "1px solid #cbd5f5",
+              fontSize: "14px",
+            }}
+          >
+            <option value="">Select a node</option>
+            {sortedNodes.map((node) => (
+              <option key={node.id} value={node.id}>
+                {node.name}
+              </option>
+            ))}
+          </select>
+          {firstNodeId && secondNodeId && firstNodeId === secondNodeId && (
+            <div style={{ color: "#dc2626", fontSize: "11.5px", marginTop: "6px" }}>
+              Please choose two different nodes.
+            </div>
+          )}
+        </div>
+
+        <div style={{ marginTop: "16px" }}>
+          <label
+            style={{
+              display: "block",
+              marginBottom: "6px",
+              fontSize: "13px",
+              fontWeight: 600,
+            }}
+          >
+            Relationship type
+          </label>
+          <input
+            type="text"
+            value={relationshipType}
+            onChange={(event) => setRelationshipType(event.target.value)}
+            placeholder="e.g. depends on, reinforces"
+            style={{
+              width: "100%",
+              padding: "12px",
+              borderRadius: "8px",
+              border: "1px solid #cbd5f5",
+              fontSize: "14px",
+            }}
+          />
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "flex-end",
+            gap: "12px",
+            marginTop: "24px",
+          }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            style={{
+              border: "none",
+              background: "#e2e8f0",
+              color: "#0f172a",
+              padding: "10px 18px",
+              borderRadius: "8px",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={!firstNodeId || !secondNodeId || firstNodeId === secondNodeId}
+            style={{
+              border: "none",
+              background:
+                !firstNodeId || !secondNodeId || firstNodeId === secondNodeId
+                  ? "#94a3b8"
+                  : "#2563eb",
+              color: "#fff",
+              padding: "10px 18px",
+              borderRadius: "8px",
+              fontWeight: 600,
+              cursor:
+                !firstNodeId || !secondNodeId || firstNodeId === secondNodeId
+                  ? "not-allowed"
+                  : "pointer",
+              boxShadow:
+                !firstNodeId || !secondNodeId || firstNodeId === secondNodeId
+                  ? "none"
+                  : "0 12px 26px rgba(37, 99, 235, 0.35)",
+            }}
+          >
+            Save edge
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default EdgeInputModal;
+

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -16,6 +16,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     targetY,
     style,
     markerEnd,
+    markerStart,
     data,
   } = props;
 
@@ -147,12 +148,12 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
 
   return (
     <>
-      <BaseEdge path={edgePath} style={style} markerEnd={markerEnd} />
-      <path
-        d={edgePath}
-        fill="none"
-        stroke="transparent"
-        strokeWidth={20}
+      <BaseEdge
+        path={edgePath}
+        style={style}
+        markerEnd={markerEnd}
+        markerStart={markerStart}
+        interactionWidth={28}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       />

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePanel.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePanel.tsx
@@ -1,0 +1,443 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import KnowledgeCapsule from "../KnowledgeCapsule";
+
+interface Concept {
+  id: string;
+  name: string;
+  description?: string;
+}
+
+interface Topic {
+  id: string;
+  name: string;
+  description?: string;
+  notes?: string;
+  concepts?: Concept[];
+}
+
+interface KnowledgePanelProps {
+  topicId?: string;
+  conceptName?: string;
+}
+
+const STUDENT_ID = "1";
+
+const normalize = (value?: string) => value?.trim().toLowerCase() ?? "";
+
+const extractTextFromNode = (node: any): string => {
+  if (!node) {
+    return "";
+  }
+
+  if (typeof node.text === "string") {
+    return node.text;
+  }
+
+  if (Array.isArray(node.children)) {
+    return node.children.map(extractTextFromNode).join("");
+  }
+
+  return "";
+};
+
+const extractConceptNotes = (notes: string, conceptName: string): string[] => {
+  try {
+    const parsed = JSON.parse(notes);
+    const children: any[] = parsed?.root?.children ?? [];
+    const target = normalize(conceptName);
+    const collected: string[] = [];
+    let capturing = false;
+
+    for (const child of children) {
+      if (child.type === "heading") {
+        const headingText = normalize(extractTextFromNode(child));
+        if (headingText === target) {
+          capturing = true;
+          continue;
+        }
+
+        if (capturing) {
+          break;
+        }
+      }
+
+      if (capturing) {
+        const text = extractTextFromNode(child).trim();
+        if (text) {
+          collected.push(text);
+        }
+      }
+    }
+
+    return collected;
+  } catch (error) {
+    console.error("Failed to parse notes for concept preview", error);
+    return [];
+  }
+};
+
+const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName }) => {
+  const [topic, setTopic] = useState<Topic | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const showConceptView = Boolean(conceptName);
+
+  useEffect(() => {
+    if (!showConceptView) {
+      setTopic(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let ignore = false;
+
+    const fetchTopic = async () => {
+      if (!topicId) {
+        setTopic(null);
+        setLoading(false);
+        setError(null);
+        return;
+      }
+
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await fetch(
+          `/api/student/${STUDENT_ID}/topic/${topicId}/notes/`
+        );
+        if (!response.ok) {
+          throw new Error(`Failed to load topic ${topicId}`);
+        }
+
+        const topicData = (await response.json()) as Topic;
+
+        if (!ignore) {
+          setTopic(topicData);
+        }
+      } catch (err) {
+        if (!ignore) {
+          console.error("Failed to load topic notes", err);
+          setError("Unable to load knowledge capsule content.");
+          setTopic(null);
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    };
+
+    fetchTopic();
+
+    return () => {
+      ignore = true;
+    };
+  }, [showConceptView, topicId]);
+
+  const focusedConcept = useMemo(() => {
+    if (!conceptName || !topic?.concepts) {
+      return null;
+    }
+
+    return (
+      topic.concepts.find(
+        (concept) => normalize(concept.name) === normalize(conceptName)
+      ) ?? null
+    );
+  }, [conceptName, topic?.concepts]);
+
+  const conceptNotes = useMemo(() => {
+    if (!conceptName || !topic?.notes) {
+      return [];
+    }
+
+    return extractConceptNotes(topic.notes, conceptName);
+  }, [conceptName, topic?.notes]);
+
+  const panelTitle = conceptName ?? topic?.name ?? "Knowledge capsule";
+
+  if (!topicId) {
+    return (
+      <div
+        style={{
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#64748b",
+          fontStyle: "italic",
+          fontFamily: "'GlacialIndifference', sans-serif",
+        }}
+      >
+        Select a node to preview its knowledge capsule content.
+      </div>
+    );
+  }
+
+  if (showConceptView && loading) {
+    return (
+      <div
+        style={{
+          height: "100%",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          color: "#64748b",
+          fontFamily: "'GlacialIndifference', sans-serif",
+        }}
+      >
+        Loading knowledge capsule...
+      </div>
+    );
+  }
+
+  if (showConceptView && error) {
+    return (
+      <div
+        style={{
+          padding: "16px",
+          color: "#dc2626",
+          fontFamily: "'GlacialIndifference', sans-serif",
+        }}
+      >
+        {error}
+      </div>
+    );
+  }
+
+  if (showConceptView && !topic) {
+    return (
+      <div
+        style={{
+          padding: "16px",
+          color: "#64748b",
+          fontFamily: "'GlacialIndifference', sans-serif",
+        }}
+      >
+        No knowledge capsule content available.
+      </div>
+    );
+  }
+
+  if (!showConceptView) {
+    return (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          overflow: "auto",
+        }}
+      >
+        <KnowledgeCapsule topicIdOverride={topicId} hideBackButton />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        padding: "16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px",
+        fontFamily: "'GlacialIndifference', sans-serif",
+        color: "#0f172a",
+      }}
+    >
+      <div>
+        <div
+          style={{
+            fontSize: "13px",
+            fontWeight: 600,
+            color: "rgba(15, 23, 42, 0.6)",
+            textTransform: "uppercase",
+            letterSpacing: "0.08em",
+            marginBottom: "6px",
+          }}
+        >
+          Knowledge Capsule
+        </div>
+        <h3 style={{ margin: 0, fontSize: "20px", fontWeight: 700 }}>{panelTitle}</h3>
+      </div>
+
+      {showConceptView ? (
+        <div
+          style={{
+            background: "#f8fafc",
+            borderRadius: "12px",
+            border: "1px solid #e2e8f0",
+            padding: "16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "12px",
+            overflowY: "auto",
+            maxHeight: "100%",
+          }}
+        >
+          {focusedConcept ? (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px solid #dbeafe",
+                padding: "14px",
+                boxShadow: "0 10px 24px rgba(148, 163, 184, 0.18)",
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: "15px" }}>
+                Concept overview
+              </div>
+              {focusedConcept.description ? (
+                <p style={{ marginTop: "8px", fontSize: "13px", lineHeight: 1.6 }}>
+                  {focusedConcept.description}
+                </p>
+              ) : (
+                <p style={{ marginTop: "8px", fontSize: "13px", color: "#64748b" }}>
+                  No concept description available.
+                </p>
+              )}
+            </div>
+          ) : (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px dashed #d6d3f0",
+                padding: "16px",
+                color: "#64748b",
+                fontStyle: "italic",
+              }}
+            >
+              This concept is not documented in the knowledge capsule yet.
+            </div>
+          )}
+
+          {conceptNotes.length > 0 && (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px solid #cbd5f5",
+                padding: "16px",
+                display: "flex",
+                flexDirection: "column",
+                gap: "10px",
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: "14px" }}>
+                Notes from knowledge capsule
+              </div>
+              {conceptNotes.map((paragraph, index) => (
+                <p key={index} style={{ margin: 0, fontSize: "13px", lineHeight: 1.6 }}>
+                  {paragraph}
+                </p>
+              ))}
+            </div>
+          )}
+
+          {conceptNotes.length === 0 && focusedConcept && (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px dashed #d6d3f0",
+                padding: "16px",
+                color: "#64748b",
+                fontSize: "12.5px",
+              }}
+            >
+              The notes for this concept are empty. Visit the full knowledge capsule to add
+              more details.
+            </div>
+          )}
+        </div>
+      ) : (
+        <div
+          style={{
+            background: "#f8fafc",
+            borderRadius: "12px",
+            border: "1px solid #e2e8f0",
+            padding: "16px",
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            overflowY: "auto",
+            maxHeight: "100%",
+          }}
+        >
+          {topic.description && (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px solid #dbeafe",
+                padding: "16px",
+                boxShadow: "0 10px 24px rgba(148, 163, 184, 0.18)",
+                fontSize: "13px",
+                lineHeight: 1.6,
+              }}
+            >
+              {topic.description}
+            </div>
+          )}
+
+          {topic.concepts && topic.concepts.length > 0 && (
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                gap: "12px",
+              }}
+            >
+              <div style={{ fontWeight: 700, fontSize: "14px" }}>
+                Concepts in this topic
+              </div>
+              {topic.concepts.map((concept) => (
+                <div
+                  key={concept.id}
+                  style={{
+                    background: "#fff",
+                    borderRadius: "10px",
+                    border: "1px solid #e2e8f0",
+                    padding: "14px",
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: "6px",
+                  }}
+                >
+                  <div style={{ fontWeight: 600 }}>{concept.name}</div>
+                  <div style={{ fontSize: "12.5px", color: "#475569" }}>
+                    {concept.description || "No description yet."}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {!topic.description && (!topic.concepts || topic.concepts.length === 0) && (
+            <div
+              style={{
+                background: "#fff",
+                borderRadius: "10px",
+                border: "1px dashed #d6d3f0",
+                padding: "16px",
+                color: "#64748b",
+                fontStyle: "italic",
+                fontSize: "12.5px",
+              }}
+            >
+              This topic has not been documented yet.
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default KnowledgePanel;
+


### PR DESCRIPTION
## Summary
- allow edge selection, deletion, and creation through a dedicated modal while preserving existing d3 layout behavior
- embed knowledge capsule content inside the movable thread-map popup, focusing on selected concepts when available
- refine layout utilities so topic labels avoid overlap with concept nodes and extract supporting helpers into dedicated files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb88d905483329c477b3f2d905b70