### PR TITLE
Fix quiz fetching by normalizing stored quiz data

### DIFF
--- a/nala/backend/app/models.py
+++ b/nala/backend/app/models.py
@@ -165,6 +165,41 @@ class StudentQuizHistory(models.Model):
     def __str__(self):
         return f"QuizHistory: {self.student.name} - Module: {self.module.name if self.module else 'N/A'} ({self.quiz_type})"
 
+    def get_questions(self):
+        """Return the list of quiz questions regardless of stored format."""
+        data = self.quiz_data
+
+        if isinstance(data, dict):
+            questions = data.get('questions', [])
+            return questions if isinstance(questions, list) else []
+
+        if isinstance(data, list):
+            return data
+
+        return []
+
+    def get_topic_ids(self):
+        """Return topic IDs from the JSON payload or the M2M relation."""
+        data = self.quiz_data
+
+        if isinstance(data, dict):
+            topic_ids = data.get('topic_ids')
+            if isinstance(topic_ids, (list, tuple)):
+                return [str(tid) for tid in topic_ids if str(tid)]
+
+        return [str(topic_id) for topic_id in self.topics_covered.values_list('id', flat=True)]
+
+    def get_effective_quiz_type(self):
+        """Determine the quiz type using the JSON payload or the model field."""
+        data = self.quiz_data
+
+        if isinstance(data, dict):
+            quiz_type = data.get('quiz_type')
+            if isinstance(quiz_type, str) and quiz_type:
+                return quiz_type
+
+        return self.quiz_type or 'weekly'
+
 
 # === Bloom Records ===
 class StudentBloomRecord(models.Model):

--- a/nala/backend/app/services/blooms.py
+++ b/nala/backend/app/services/blooms.py
@@ -279,11 +279,12 @@ def update_bloom_from_quiz(
     if not record.bloom_summary:
         record.bloom_summary = {}
 
-    questions = quiz_history.quiz_data.get('questions', [])
-    student_answers = quiz_history.student_answers
+    questions = quiz_history.get_questions()
+    student_answers = quiz_history.student_answers or {}
 
     for idx, question in enumerate(questions):
-        if student_answers.get(str(idx)) != question.get('correct_answer'):
+        correct_answer = question.get('answer') or question.get('correct_answer')
+        if student_answers.get(str(idx)) != correct_answer:
             continue
         topic_id = str(question.get('topic_id'))
         bloom_level = question.get('bloom_level')
@@ -346,7 +347,7 @@ def update_bloom_from_quiz(student, quiz_history):
     """
     from app.models import StudentBloomRecord, Topic
     
-    questions = quiz_history.quiz_data.get('questions', [])
+    questions = quiz_history.get_questions()
     student_answers = quiz_history.student_answers or {}
     module = quiz_history.module
     
@@ -364,7 +365,7 @@ def update_bloom_from_quiz(student, quiz_history):
     
     for idx, question in enumerate(questions):
         student_answer = student_answers.get(str(idx))
-        correct_answer = question.get('answer')
+        correct_answer = question.get('answer') or question.get('correct_answer')
         
         if student_answer != correct_answer:
             continue

--- a/nala/backend/app/views.py
+++ b/nala/backend/app/views.py
@@ -183,7 +183,7 @@ def get_weekly_quiz(request, module_id):
                 status=status.HTTP_400_BAD_REQUEST
             )
         
-        topic_ids = [tid.strip() for tid in topic_ids_param.split(',')]
+        topic_ids = [tid.strip() for tid in topic_ids_param.split(',') if tid.strip()]
         topic_ids_set = set(topic_ids)
         
         topics = Topic.objects.filter(module=module, id__in=topic_ids)
@@ -199,12 +199,12 @@ def get_weekly_quiz(request, module_id):
         candidate_quizzes = StudentQuizHistory.objects.filter(
             student=student,
             module=module,
-            quiz_data__quiz_type='weekly'
+            quiz_type='weekly'
         )
         
         for quiz in candidate_quizzes:
-            stored_topic_ids = [str(tid) for tid in quiz.quiz_data.get('topic_ids', [])]
-            if set(stored_topic_ids) == topic_ids_set:
+            stored_topic_ids = set(quiz.get_topic_ids())
+            if stored_topic_ids == topic_ids_set:
                 existing_quiz = quiz
                 break
         
@@ -214,13 +214,15 @@ def get_weekly_quiz(request, module_id):
                 status=status.HTTP_404_NOT_FOUND
             )
         
+        questions = existing_quiz.get_questions()
+
         return Response({
             'quiz_history_id': str(existing_quiz.id),
-            'questions': existing_quiz.quiz_data.get('questions', []),
+            'questions': questions,
             'student_answers': existing_quiz.student_answers or {},
             'completed': existing_quiz.completed,
             'score': existing_quiz.score,
-            'can_retry': True,
+            'can_retry': existing_quiz.get_effective_quiz_type() == 'weekly',
         })
         
     except Student.DoesNotExist:
@@ -309,7 +311,8 @@ def generate_custom_quiz(request, module_id):
             },
             student_answers={},
             completed=False,
-            score=None
+            score=None,
+            quiz_type='custom'
         )
         
         quiz_history.topics_covered.set(topics)
@@ -381,12 +384,13 @@ def submit_quiz(request, quiz_history_id):
         
         quiz_history.student_answers = {str(k): v for k, v in answers.items()}
         
-        questions = quiz_history.quiz_data.get('questions', [])
+        questions = quiz_history.get_questions()
         correct_count = 0
-        
+
         for idx, question in enumerate(questions):
             student_answer = quiz_history.student_answers.get(str(idx))
-            if student_answer == question.get('answer'):
+            correct_answer = question.get('answer') or question.get('correct_answer')
+            if student_answer == correct_answer:
                 correct_count += 1
         
         score = (correct_count / len(questions)) * 100 if questions else 0
@@ -397,7 +401,7 @@ def submit_quiz(request, quiz_history_id):
         
         update_bloom_from_quiz(quiz_history.student, quiz_history)
         
-        quiz_type = quiz_history.quiz_data.get('quiz_type', 'unknown')
+        quiz_type = quiz_history.get_effective_quiz_type()
         
         return Response({
             'status': 'success',
@@ -425,15 +429,16 @@ def get_quiz_history(request, student_id):
             student=student,
             completed=True
         ).order_by('-created_at')
-        
+
         history_data = []
         for quiz in quiz_histories:
+            questions = quiz.get_questions()
             history_data.append({
                 'id': quiz.id,
                 'module_name': quiz.module.name if quiz.module else 'N/A',
                 'score': quiz.score,
-                'num_questions': len(quiz.quiz_data.get('questions', [])),
-                'quiz_type': quiz.quiz_data.get('quiz_type', 'unknown'),
+                'num_questions': len(questions),
+                'quiz_type': quiz.get_effective_quiz_type(),
                 'created_at': quiz.created_at.isoformat(),
             })
         


### PR DESCRIPTION
## Summary
- add helper methods on StudentQuizHistory to normalize questions, topics, and quiz type metadata stored in JSON
- update quiz views to rely on the new helpers, ensure custom quizzes persist their type, and safely compare answers
- adjust Bloom service functions to use the normalized quiz data when updating Bloom records

## Testing
- python -m compileall nala/backend/app

------
https://chatgpt.com/codex/tasks/task_e_68dc04a09cc883329f4b2afffdf750d4