### PR TITLE
Improve thread map interactions and taxonomy data loading

### DIFF
--- a/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
@@ -160,14 +160,17 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
     Create: "#4C73FF",
   };
 
-  const bloomOrder = [
-    "Remember",
-    "Understand",
-    "Apply",
-    "Analyze",
-    "Evaluate",
-    "Create",
-  ];
+  const bloomOrder = useMemo(
+    () => [
+      "Remember",
+      "Understand",
+      "Apply",
+      "Analyze",
+      "Evaluate",
+      "Create",
+    ],
+    []
+  );
 
   const normalizeModuleValue = (value: string) =>
     value
@@ -246,20 +249,138 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
   };
 
   useEffect(() => {
+    let ignore = false;
+    const controller = new AbortController();
+
+    const normalizeCounts = (
+      counts: unknown
+    ): Record<string, number> | null => {
+      if (!counts || typeof counts !== "object") {
+        return null;
+      }
+
+      const result: Record<string, number> = {};
+      let hasValue = false;
+      bloomOrder.forEach((level) => {
+        const value = Number((counts as Record<string, unknown>)[level]);
+        if (!Number.isNaN(value)) {
+          result[level] = value;
+          if (value > 0) {
+            hasValue = true;
+          }
+        } else {
+          result[level] = 0;
+        }
+      });
+
+      return hasValue || Object.keys(result).length > 0 ? result : null;
+    };
+
+    const normalizeEntry = (entry: unknown): TopicData | null => {
+      if (!entry || typeof entry !== "object") {
+        return null;
+      }
+
+      const source = entry as Record<string, unknown>;
+      const moduleName =
+        typeof source.module === "string"
+          ? source.module
+          : typeof source.module_name === "string"
+          ? source.module_name
+          : typeof source.module_info === "object" && source.module_info !== null
+          ? ((source.module_info as Record<string, unknown>).name as string | undefined)
+          : undefined;
+      const topicName =
+        typeof source.topic === "string"
+          ? source.topic
+          : typeof source.topic_name === "string"
+          ? source.topic_name
+          : typeof source.name === "string"
+          ? source.name
+          : undefined;
+      const counts =
+        normalizeCounts(source.bloom_level_counts) ??
+        normalizeCounts(source.counts) ??
+        normalizeCounts(source.bloom_levels);
+
+      if (!moduleName || !topicName || !counts) {
+        return null;
+      }
+
+      return {
+        module: moduleName,
+        topic: topicName,
+        bloom_level_counts: counts,
+      };
+    };
+
+    const normalizePayload = (payload: unknown): TopicData[] => {
+      if (!payload) {
+        return [];
+      }
+
+      if (Array.isArray(payload)) {
+        return payload
+          .map(normalizeEntry)
+          .filter((item): item is TopicData => Boolean(item));
+      }
+
+      if (typeof payload === "object") {
+        const source = payload as Record<string, unknown>;
+        if (Array.isArray(source.summary)) {
+          return normalizePayload(source.summary);
+        }
+        if (Array.isArray(source.data)) {
+          return normalizePayload(source.data);
+        }
+      }
+
+      return [];
+    };
+
     const fetchData = async () => {
+      setLoading(true);
       try {
-        console.log("Loading dummy data...");
-        setRawData(dummyData.summary || []);
-        console.log("rawData set:", dummyData.summary?.length);
+        const response = await fetch("/api/taxonomy-progression/", {
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error(`Failed to fetch topic progression: ${response.status}`);
+        }
+
+        const payload = await response.json();
+        if (ignore) {
+          return;
+        }
+
+        const parsed = normalizePayload(payload);
+        if (parsed.length > 0) {
+          setRawData(parsed);
+        } else {
+          setRawData(dummyData.summary || []);
+        }
       } catch (error) {
-        console.error("Failed to fetch topic progression", error);
+        if (ignore) {
+          return;
+        }
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          console.error("Failed to fetch topic progression", error);
+        }
+        setRawData(dummyData.summary || []);
       } finally {
-        console.log("Setting loading = false");
-        setLoading(false);
+        if (!ignore) {
+          setLoading(false);
+        }
       }
     };
+
     fetchData();
-  }, []);
+
+    return () => {
+      ignore = true;
+      controller.abort();
+    };
+  }, [bloomOrder]);
 
   useEffect(() => {
     if (!passedModule) {

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -18,6 +18,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     markerEnd,
     markerStart,
     data,
+    selected,
   } = props;
 
   const { getEdges, getNode } = useReactFlow<FlowNode, FlowEdge>();
@@ -146,6 +147,13 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
 
   const [isHovered, setIsHovered] = useState(false);
 
+  const showLabelFromNodeHover =
+    typeof data === "object" && data !== null
+      ? Boolean((data as { showLabel?: boolean }).showLabel)
+      : false;
+  const hasLabel = typeof data?.label === "string" && data.label.trim() !== "";
+  const shouldRenderLabel = hasLabel && (isHovered || showLabelFromNodeHover || Boolean(selected));
+
   return (
     <>
       <BaseEdge
@@ -157,9 +165,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       />
-      {isHovered &&
-        typeof data?.label === "string" &&
-        data.label.trim() !== "" && (
+      {shouldRenderLabel && (
           <EdgeLabelRenderer>
             <div
               style={{

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePopup.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePopup.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import { Maximize2, Minimize2 } from "lucide-react";
 
 interface KnowledgePopupProps {
@@ -28,6 +28,20 @@ const KnowledgePopup: React.FC<KnowledgePopupProps> = ({
   onResizeMouseDown,
   children,
 }) => {
+  const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!scrollContainerRef.current) {
+      return;
+    }
+
+    scrollContainerRef.current.scrollTo({
+      top: 0,
+      left: 0,
+      behavior: "auto",
+    });
+  }, [children, isExpanded, title]);
+
   return (
     <div
       style={{
@@ -129,7 +143,12 @@ const KnowledgePopup: React.FC<KnowledgePopupProps> = ({
           padding: "16px",
         }}
       >
-        <div style={{ height: "100%", overflow: "auto" }}>{children}</div>
+        <div
+          ref={scrollContainerRef}
+          style={{ height: "100%", overflow: "auto" }}
+        >
+          {children}
+        </div>
       </div>
       <div
         onMouseDown={onResizeMouseDown}


### PR DESCRIPTION
## Summary
- prevent concept note parsing failures by handling rich text and plain text notes while resetting scroll positions for previews
- surface edge relationship labels on hover, refactor Bloom summary fetching to combine module results, and show the quick guide on info hover
- scroll the embedded knowledge popup to the top when opened and load taxonomy progression data from the API with resilient normalization

## Testing
- not run (UI changes)

------
https://chatgpt.com/codex/tasks/task_e_68dc27a0a2188332b18cdb0c3e549e2c