### PR TITLE
Handle stalled topic taxonomy progression requests

### DIFF
--- a/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
+++ b/nala/frontend/nalaLearnscape/src/components/TopicTaxonomyProgression.tsx
@@ -251,6 +251,16 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
   useEffect(() => {
     let ignore = false;
     const controller = new AbortController();
+    const REQUEST_TIMEOUT_MS = 8000;
+
+    const timeoutId = window.setTimeout(() => {
+      if (!ignore) {
+        console.warn(
+          "Topic taxonomy progression request timed out. Falling back to cached data."
+        );
+        controller.abort();
+      }
+    }, REQUEST_TIMEOUT_MS);
 
     const normalizeCounts = (
       counts: unknown
@@ -368,6 +378,7 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
         }
         setRawData(dummyData.summary || []);
       } finally {
+        clearTimeout(timeoutId);
         if (!ignore) {
           setLoading(false);
         }
@@ -378,6 +389,7 @@ const TopicTaxonomyProgression: React.FC<TopicTaxonomyProgressionProps> = ({
 
     return () => {
       ignore = true;
+      clearTimeout(timeoutId);
       controller.abort();
     };
   }, [bloomOrder]);


### PR DESCRIPTION
## Summary
- add a timeout guard for the taxonomy progression fetch request so the UI can fall back to cached data when the backend does not respond
- ensure the loading indicator is cleared even when a timeout occurs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc31547f148332af25c5dfeccdfceb