### PR TITLE
Refine thread map knowledge previews and bloom levels

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/HoverLabelEdge.tsx
@@ -151,7 +151,13 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
     typeof data === "object" && data !== null
       ? Boolean((data as { showLabel?: boolean }).showLabel)
       : false;
-  const hasLabel = typeof data?.label === "string" && data.label.trim() !== "";
+  const labelText =
+    typeof data?.label === "string"
+      ? data.label
+      : typeof data?.label === "number"
+      ? String(data.label)
+      : "";
+  const hasLabel = labelText.trim() !== "";
   const shouldRenderLabel = hasLabel && (isHovered || showLabelFromNodeHover || Boolean(selected));
 
   return (
@@ -161,7 +167,7 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
         style={style}
         markerEnd={markerEnd}
         markerStart={markerStart}
-        interactionWidth={28}
+        interactionWidth={48}
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       />
@@ -172,15 +178,17 @@ const HoverLabelEdge: React.FC<EdgeProps> = (props) => {
                 position: "absolute",
                 transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
                 pointerEvents: "none",
-                background: "rgba(0, 0, 0, 0.75)",
-                color: "#fff",
-                padding: "4px 8px",
-                borderRadius: "4px",
-                fontSize: "10px",
+                background: "rgba(15, 23, 42, 0.92)",
+                color: "#f8fafc",
+                padding: "6px 10px",
+                borderRadius: "6px",
+                fontSize: "11px",
                 whiteSpace: "nowrap",
+                boxShadow: "0 8px 16px rgba(15, 23, 42, 0.3)",
+                fontFamily: '"GlacialIndifference", sans-serif',
               }}
             >
-              {data.label}
+              {labelText}
             </div>
           </EdgeLabelRenderer>
         )}

--- a/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePanel.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/threadMap/KnowledgePanel.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 
-import KnowledgeCapsule from "../KnowledgeCapsule";
-
 interface Concept {
   id: string;
   name: string;
@@ -41,122 +39,146 @@ const extractTextFromNode = (node: any): string => {
   return "";
 };
 
-const extractConceptNotesFromPlainText = (
-  notes: string,
-  conceptName: string
-): string[] => {
-  const target = normalize(conceptName);
+interface KnowledgeBlock {
+  type: "heading" | "paragraph";
+  text: string;
+  tag?: string;
+}
+
+const parsePlainTextNotes = (notes: string): KnowledgeBlock[] => {
   const lines = notes.split(/\r?\n/);
-  const collected: string[] = [];
-  let capturing = false;
+  const blocks: KnowledgeBlock[] = [];
+  let paragraphBuffer: string[] = [];
+
+  const flushParagraph = () => {
+    if (paragraphBuffer.length === 0) {
+      return;
+    }
+
+    const paragraphText = paragraphBuffer.join(" ").trim();
+    paragraphBuffer = [];
+
+    if (paragraphText.length === 0) {
+      return;
+    }
+
+    blocks.push({ type: "paragraph", text: paragraphText });
+  };
 
   for (const rawLine of lines) {
     const line = rawLine.trim();
+
     if (!line) {
-      if (capturing && collected.length > 0) {
-        break;
-      }
+      flushParagraph();
       continue;
     }
 
-    const normalizedLine = normalize(line.replace(/[:\-]+$/, ""));
-
-    if (!capturing) {
-      if (
-        normalizedLine === target ||
-        normalizedLine.includes(target)
-      ) {
-        capturing = true;
-      }
+    const headingMatch = line.match(/^(#{1,6})\s+(.*)$/);
+    if (headingMatch) {
+      flushParagraph();
+      const [, hashes, headingText] = headingMatch;
+      blocks.push({
+        type: "heading",
+        text: headingText.trim(),
+        tag: `h${Math.min(hashes.length, 6)}`,
+      });
       continue;
     }
 
-    if (/^#{1,6}\s/.test(line)) {
-      break;
-    }
-
-    collected.push(line);
+    paragraphBuffer.push(line);
   }
 
-  if (collected.length > 0) {
-    return collected;
-  }
+  flushParagraph();
 
-  return notes
-    .split(/\r?\n{2,}/)
-    .map((block) => block.replace(/\r?\n/g, " ").trim())
-    .filter((block) => block.length > 0)
-    .slice(0, 3);
+  return blocks;
 };
 
-const extractConceptNotes = (notes: string, conceptName: string): string[] => {
+const parseStructuredNotes = (notes: string): KnowledgeBlock[] => {
+  try {
+    const parsed = JSON.parse(notes);
+    const children: any[] = parsed?.root?.children ?? [];
+
+    const blocks: KnowledgeBlock[] = [];
+
+    const addBlock = (block: KnowledgeBlock) => {
+      if (!block.text || block.text.trim().length === 0) {
+        return;
+      }
+      blocks.push({ ...block, text: block.text.trim() });
+    };
+
+    for (const child of children) {
+      if (!child) {
+        continue;
+      }
+
+      if (child.type === "heading") {
+        addBlock({
+          type: "heading",
+          text: extractTextFromNode(child),
+          tag: typeof child.tag === "string" ? child.tag : undefined,
+        });
+      } else if (child.type === "paragraph") {
+        addBlock({
+          type: "paragraph",
+          text: extractTextFromNode(child),
+        });
+      } else if (Array.isArray(child.children)) {
+        child.children.forEach((nested: any) => {
+          if (nested?.type === "heading") {
+            addBlock({
+              type: "heading",
+              text: extractTextFromNode(nested),
+              tag: typeof nested.tag === "string" ? nested.tag : undefined,
+            });
+          } else if (nested?.type === "paragraph") {
+            addBlock({
+              type: "paragraph",
+              text: extractTextFromNode(nested),
+            });
+          }
+        });
+      }
+    }
+
+    return blocks;
+  } catch (error) {
+    if (!(error instanceof SyntaxError)) {
+      console.warn("Failed to parse structured knowledge capsule notes", error);
+    }
+    return parsePlainTextNotes(notes);
+  }
+};
+
+const parseTopicNotes = (notes?: string | null): KnowledgeBlock[] => {
+  if (!notes) {
+    return [];
+  }
+
   const trimmed = notes.trim();
   if (!trimmed) {
     return [];
   }
 
   const looksLikeJson = trimmed.startsWith("{") || trimmed.startsWith("[");
-
-  if (!looksLikeJson) {
-    return extractConceptNotesFromPlainText(trimmed, conceptName);
-  }
-
-  try {
-    const parsed = JSON.parse(trimmed);
-    const children: any[] = parsed?.root?.children ?? [];
-    const target = normalize(conceptName);
-    const collected: string[] = [];
-    let capturing = false;
-
-    for (const child of children) {
-      if (child.type === "heading") {
-        const headingText = normalize(extractTextFromNode(child));
-        if (headingText === target) {
-          capturing = true;
-          continue;
-        }
-
-        if (capturing) {
-          break;
-        }
-      }
-
-      if (capturing) {
-        const text = extractTextFromNode(child).trim();
-        if (text) {
-          collected.push(text);
-        }
-      }
-    }
-
-    if (collected.length > 0) {
-      return collected;
-    }
-  } catch (error) {
-    if (!(error instanceof SyntaxError)) {
-      console.warn("Failed to parse structured notes for concept preview", error);
-    }
-  }
-
-  return extractConceptNotesFromPlainText(trimmed, conceptName);
+  return looksLikeJson
+    ? parseStructuredNotes(trimmed)
+    : parsePlainTextNotes(trimmed);
 };
 
-const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName }) => {
+const KnowledgePanel: React.FC<KnowledgePanelProps> = ({
+  topicId,
+  conceptName,
+}) => {
   const [topic, setTopic] = useState<Topic | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+  const blockRefs = useRef<(HTMLDivElement | null)[]>([]);
 
   const showConceptView = Boolean(conceptName);
 
   useEffect(() => {
-    if (!showConceptView) {
-      setTopic(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-
     let ignore = false;
 
     const fetchTopic = async () => {
@@ -167,10 +189,9 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
         return;
       }
 
-      setLoading(true);
-      setError(null);
-
       try {
+        setLoading(true);
+        setError(null);
         const response = await fetch(
           `/api/student/${STUDENT_ID}/topic/${topicId}/notes/`
         );
@@ -201,7 +222,7 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     return () => {
       ignore = true;
     };
-  }, [showConceptView, topicId]);
+  }, [topicId]);
 
   const focusedConcept = useMemo(() => {
     if (!conceptName || !topic?.concepts) {
@@ -215,13 +236,51 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     );
   }, [conceptName, topic?.concepts]);
 
-  const conceptNotes = useMemo(() => {
-    if (!conceptName || !topic?.notes) {
-      return [];
+  const knowledgeBlocks = useMemo(() => {
+    const parsed = parseTopicNotes(topic?.notes);
+
+    if (parsed.length > 0) {
+      return parsed;
     }
 
-    return extractConceptNotes(topic.notes, conceptName);
-  }, [conceptName, topic?.notes]);
+    const fallback: KnowledgeBlock[] = [];
+
+    if (topic?.description) {
+      fallback.push({ type: "paragraph", text: topic.description });
+    }
+
+    if (topic?.concepts) {
+      topic.concepts.forEach((concept) => {
+        fallback.push({ type: "heading", text: concept.name, tag: "h3" });
+        if (concept.description) {
+          fallback.push({ type: "paragraph", text: concept.description });
+        }
+      });
+    }
+
+    return fallback;
+  }, [topic?.concepts, topic?.description, topic?.notes]);
+
+  const focusBlockIndex = useMemo(() => {
+    if (!showConceptView || !conceptName) {
+      return 0;
+    }
+
+    const target = normalize(conceptName);
+    const index = knowledgeBlocks.findIndex((block) => {
+      if (block.type !== "heading") {
+        return false;
+      }
+
+      return normalize(block.text) === target;
+    });
+
+    return index >= 0 ? index : 0;
+  }, [conceptName, knowledgeBlocks, showConceptView]);
+
+  useEffect(() => {
+    blockRefs.current = [];
+  }, [knowledgeBlocks]);
 
   const panelTitle = conceptName ?? topic?.name ?? "Knowledge capsule";
 
@@ -229,9 +288,26 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     if (!scrollContainerRef.current) {
       return;
     }
+    const container = scrollContainerRef.current;
 
-    scrollContainerRef.current.scrollTo({ top: 0, left: 0, behavior: "auto" });
-  }, [showConceptView, topicId, conceptName, topic?.id, topic?.notes]);
+    if (showConceptView) {
+      const target = blockRefs.current[focusBlockIndex];
+      if (target) {
+        const top = target.offsetTop;
+        container.scrollTo({ top: Math.max(top - 12, 0), left: 0, behavior: "auto" });
+        return;
+      }
+    }
+
+    container.scrollTo({ top: 0, left: 0, behavior: "auto" });
+  }, [
+    conceptName,
+    focusBlockIndex,
+    knowledgeBlocks,
+    showConceptView,
+    topic?.id,
+    topicId,
+  ]);
 
   if (!topicId) {
     return (
@@ -251,7 +327,7 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     );
   }
 
-  if (showConceptView && loading) {
+  if (loading) {
     return (
       <div
         style={{
@@ -268,7 +344,7 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     );
   }
 
-  if (showConceptView && error) {
+  if (error) {
     return (
       <div
         style={{
@@ -282,7 +358,7 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     );
   }
 
-  if (showConceptView && !topic) {
+  if (!topic) {
     return (
       <div
         style={{
@@ -296,21 +372,6 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
     );
   }
 
-  if (!showConceptView) {
-    return (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          overflow: "auto",
-        }}
-        ref={scrollContainerRef}
-      >
-        <KnowledgeCapsule topicIdOverride={topicId} hideBackButton />
-      </div>
-    );
-  }
-
   return (
     <div
       style={{
@@ -320,6 +381,7 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
         gap: "16px",
         fontFamily: "'GlacialIndifference', sans-serif",
         color: "#0f172a",
+        height: "100%",
       }}
     >
       <div>
@@ -338,181 +400,121 @@ const KnowledgePanel: React.FC<KnowledgePanelProps> = ({ topicId, conceptName })
         <h3 style={{ margin: 0, fontSize: "20px", fontWeight: 700 }}>{panelTitle}</h3>
       </div>
 
-      {showConceptView ? (
+      {showConceptView && (
         <div
           style={{
-            background: "#f8fafc",
-            borderRadius: "12px",
-            border: "1px solid #e2e8f0",
+            background: "#fff",
+            borderRadius: "10px",
+            border: "1px solid #dbeafe",
             padding: "16px",
             display: "flex",
             flexDirection: "column",
-            gap: "12px",
-            overflowY: "auto",
-            maxHeight: "100%",
-          }}
-          ref={scrollContainerRef}
-        >
-          {focusedConcept ? (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px solid #dbeafe",
-                padding: "14px",
-                boxShadow: "0 10px 24px rgba(148, 163, 184, 0.18)",
-              }}
-            >
-              <div style={{ fontWeight: 700, fontSize: "15px" }}>
-                Concept overview
-              </div>
-              {focusedConcept.description ? (
-                <p style={{ marginTop: "8px", fontSize: "13px", lineHeight: 1.6 }}>
-                  {focusedConcept.description}
-                </p>
-              ) : (
-                <p style={{ marginTop: "8px", fontSize: "13px", color: "#64748b" }}>
-                  No concept description available.
-                </p>
-              )}
-            </div>
-          ) : (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px dashed #d6d3f0",
-                padding: "16px",
-                color: "#64748b",
-                fontStyle: "italic",
-              }}
-            >
-              This concept is not documented in the knowledge capsule yet.
-            </div>
-          )}
-
-          {conceptNotes.length > 0 && (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px solid #cbd5f5",
-                padding: "16px",
-                display: "flex",
-                flexDirection: "column",
-                gap: "10px",
-              }}
-            >
-              <div style={{ fontWeight: 700, fontSize: "14px" }}>
-                Notes from knowledge capsule
-              </div>
-              {conceptNotes.map((paragraph, index) => (
-                <p key={index} style={{ margin: 0, fontSize: "13px", lineHeight: 1.6 }}>
-                  {paragraph}
-                </p>
-              ))}
-            </div>
-          )}
-
-          {conceptNotes.length === 0 && focusedConcept && (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px dashed #d6d3f0",
-                padding: "16px",
-                color: "#64748b",
-                fontSize: "12.5px",
-              }}
-            >
-              The notes for this concept are empty. Visit the full knowledge capsule to add
-              more details.
-            </div>
-          )}
-        </div>
-      ) : (
-        <div
-          style={{
-            background: "#f8fafc",
-            borderRadius: "12px",
-            border: "1px solid #e2e8f0",
-            padding: "16px",
-            display: "flex",
-            flexDirection: "column",
-            gap: "16px",
-            overflowY: "auto",
-            maxHeight: "100%",
+            gap: "10px",
+            boxShadow: "0 12px 28px rgba(30, 64, 175, 0.12)",
           }}
         >
-          {topic.description && (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px solid #dbeafe",
-                padding: "16px",
-                boxShadow: "0 10px 24px rgba(148, 163, 184, 0.18)",
-                fontSize: "13px",
-                lineHeight: 1.6,
-              }}
-            >
-              {topic.description}
-            </div>
-          )}
-
-          {topic.concepts && topic.concepts.length > 0 && (
-            <div
-              style={{
-                display: "flex",
-                flexDirection: "column",
-                gap: "12px",
-              }}
-            >
-              <div style={{ fontWeight: 700, fontSize: "14px" }}>
-                Concepts in this topic
-              </div>
-              {topic.concepts.map((concept) => (
-                <div
-                  key={concept.id}
-                  style={{
-                    background: "#fff",
-                    borderRadius: "10px",
-                    border: "1px solid #e2e8f0",
-                    padding: "14px",
-                    display: "flex",
-                    flexDirection: "column",
-                    gap: "6px",
-                  }}
-                >
-                  <div style={{ fontWeight: 600 }}>{concept.name}</div>
-                  <div style={{ fontSize: "12.5px", color: "#475569" }}>
-                    {concept.description || "No description yet."}
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {!topic.description && (!topic.concepts || topic.concepts.length === 0) && (
-            <div
-              style={{
-                background: "#fff",
-                borderRadius: "10px",
-                border: "1px dashed #d6d3f0",
-                padding: "16px",
-                color: "#64748b",
-                fontStyle: "italic",
-                fontSize: "12.5px",
-              }}
-            >
-              This topic has not been documented yet.
-            </div>
-          )}
+          <div style={{ fontSize: "17px", fontWeight: 700 }}>
+            {focusedConcept?.name ?? conceptName}
+          </div>
+          <div style={{ fontSize: "13px", color: "#1e3a8a", fontWeight: 600 }}>
+            Concept focus
+          </div>
+          <div style={{ fontSize: "13px", lineHeight: 1.6 }}>
+            {focusedConcept?.description ||
+              "No description available for this concept."}
+          </div>
         </div>
       )}
+
+      <div
+        style={{
+          background: "#f8fafc",
+          borderRadius: "12px",
+          border: "1px solid #e2e8f0",
+          padding: "16px",
+          display: "flex",
+          flexDirection: "column",
+          gap: "14px",
+          overflowY: "auto",
+          maxHeight: "100%",
+        }}
+        ref={scrollContainerRef}
+      >
+        {knowledgeBlocks.length === 0 && (
+          <div
+            style={{
+              background: "#fff",
+              borderRadius: "10px",
+              border: "1px dashed #d6d3f0",
+              padding: "16px",
+              color: "#64748b",
+              fontSize: "12.5px",
+              fontStyle: "italic",
+            }}
+          >
+            This knowledge capsule does not have any saved notes yet.
+          </div>
+        )}
+
+        {knowledgeBlocks.map((block, index) => {
+          const isFocus = showConceptView && index === focusBlockIndex;
+
+          if (block.type === "heading") {
+            return (
+              <div
+                key={`${block.type}-${index}-${block.text}`}
+                ref={(element) => {
+                  blockRefs.current[index] = element;
+                }}
+                style={{
+                  padding: isFocus ? "14px 12px" : "0",
+                  borderRadius: isFocus ? "10px" : undefined,
+                  background: isFocus ? "rgba(191, 219, 254, 0.35)" : undefined,
+                  border: isFocus ? "1px solid rgba(59, 130, 246, 0.35)" : undefined,
+                  scrollMarginTop: "12px",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize:
+                      block.tag === "h1"
+                        ? "22px"
+                        : block.tag === "h2"
+                        ? "20px"
+                        : "18px",
+                    fontWeight: 700,
+                    color: isFocus ? "#1d4ed8" : "#0f172a",
+                  }}
+                >
+                  {block.text}
+                </div>
+              </div>
+            );
+          }
+
+          return (
+            <div
+              key={`${block.type}-${index}-${block.text.slice(0, 24)}`}
+              ref={(element) => {
+                blockRefs.current[index] = element;
+              }}
+              style={{
+                fontSize: "13px",
+                lineHeight: 1.6,
+                color: "#1f2937",
+                background: isFocus ? "rgba(191, 219, 254, 0.15)" : undefined,
+                borderRadius: isFocus ? "8px" : undefined,
+                padding: isFocus ? "10px 12px" : "0",
+                scrollMarginTop: "12px",
+              }}
+            >
+              {block.text}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };
 
 export default KnowledgePanel;
-


### PR DESCRIPTION
## Summary
- render knowledge capsule content inside the thread map popup using parsed topic notes, including concept-focused highlighting and automatic scrolling
- normalize Bloom taxonomy summaries from StudentBloomRecord to drive topic node badges
- widen edge hover hit areas and restyle relationship labels for clearer visibility

## Testing
- npm run build *(fails: repository lacks required dependencies such as axios, @vitejs/plugin-react, and several type definitions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc34a539cc8332a851775a8e10360b