### PR TITLE
Refine thread map bloom data and popup scrolling

### DIFF
--- a/nala/frontend/nalaLearnscape/src/pages/KnowledgeCapsule.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/KnowledgeCapsule.tsx
@@ -168,6 +168,7 @@ export default function KnowledgeCapsule({
 
     if (!topic || !normalizedFocusedConcept) {
       container.scrollTo({ top: 0, behavior: "auto" });
+      containerRef.current?.scrollTo({ top: 0, behavior: "auto" });
       return;
     }
 
@@ -190,6 +191,10 @@ export default function KnowledgeCapsule({
             const offset =
               targetRect.top - containerRect.top + container.scrollTop - 24;
             container.scrollTo({
+              top: Math.max(offset, 0),
+              behavior: "auto",
+            });
+            containerRef.current?.scrollTo({
               top: Math.max(offset, 0),
               behavior: "auto",
             });
@@ -247,8 +252,8 @@ export default function KnowledgeCapsule({
   if (!topic) return <p className="p-4">Topic not found.</p>;
 
   const containerClass = hideBackButton
-    ? "h-full bg-gradient-to-br from-slate-50 to-blue-50 p-4 md:p-6 lg:p-8 overflow-y-auto"
-    : "min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4 md:p-6 lg:p-8";
+    ? "h-full bg-gradient-to-br from-slate-50 to-blue-50 p-4 md:p-6 lg:p-8"
+    : "min-h-screen bg-gradient-to-br from-slate-50 to-blue-50 p-4 md:p-6 lg:p-8 overflow-y-auto";
   const headerClass = hideBackButton
     ? "bg-primary-dark rounded-xl shadow-lg mb-4 p-4 md:p-6 flex items-center gap-6"
     : "bg-primary-dark rounded-xl shadow-lg mb-8 p-4 md:p-6 flex items-center gap-8";

--- a/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
+++ b/nala/frontend/nalaLearnscape/src/pages/ThreadMap.tsx
@@ -110,6 +110,12 @@ const BLOOM_LEVEL_MAP = BLOOM_LEVEL_ORDER.reduce<Record<string, number>>(
   {}
 );
 
+type TopicBloomSummary = {
+  label: string | null;
+  value: number | null;
+  counts: Record<string, number> | null;
+};
+
 const getHighestBloomLevel = (
   counts?: Record<string, number> | null
 ): { label: string | null; value: number | null } => {
@@ -232,14 +238,7 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
     visible: false,
   });
   const [topicBloomLevels, setTopicBloomLevels] = useState<
-    Record<
-      string,
-      {
-        label: string | null;
-        value: number | null;
-        counts: Record<string, number> | null;
-      }
-    >
+    Record<string, TopicBloomSummary>
   >({});
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
@@ -373,18 +372,33 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
       return true;
     });
   }, [edgeTypeFilter, edges, nodes, showConceptParentEdges]);
-  const bloomModuleIds = useMemo(() => {
-    const ids = new Set<string>();
-    if (activeModuleId && activeModuleId.trim().length > 0) {
-      ids.add(String(activeModuleId));
-    }
+  const topicBloomRequests = useMemo(() => {
+    const seen = new Set<string>();
+    const requests: { moduleId: string; topicId: string }[] = [];
+
     dbNodes.forEach((node) => {
-      if (node.module_id) {
-        ids.add(String(node.module_id));
+      if (node.type !== "topic") {
+        return;
       }
+
+      const moduleId = String(node.module_id ?? "").trim();
+      const topicId = String(node.id ?? "").trim();
+
+      if (!moduleId || !topicId) {
+        return;
+      }
+
+      const key = `${moduleId}::${topicId}`;
+      if (seen.has(key)) {
+        return;
+      }
+
+      seen.add(key);
+      requests.push({ moduleId, topicId });
     });
-    return Array.from(ids).sort((a, b) => a.localeCompare(b));
-  }, [activeModuleId, dbNodes]);
+
+    return requests;
+  }, [dbNodes]);
   const activeModuleInfo = activeModuleId
     ? moduleLookup[activeModuleId]
     : undefined;
@@ -707,31 +721,26 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
   }, [popupSizing]);
 
   useEffect(() => {
-    if (bloomModuleIds.length === 0) {
+    if (topicBloomRequests.length === 0) {
       setTopicBloomLevels({});
       return;
     }
 
     let isMounted = true;
-    const controllers = bloomModuleIds.map(() => new AbortController());
+    const controllers = topicBloomRequests.map(() => new AbortController());
 
     const fetchSummaries = async () => {
-      const combined: Record<
-        string,
-        {
-          label: string | null;
-          value: number | null;
-          counts: Record<string, number> | null;
-        }
-      > = {};
+      const combined: Record<string, TopicBloomSummary> = {};
 
       await Promise.all(
-        bloomModuleIds.map(async (moduleId, index) => {
+        topicBloomRequests.map(async ({ moduleId, topicId }, index) => {
           const controller = controllers[index];
+
           try {
             const params = new URLSearchParams({
               student_id: STUDENT_ID,
               module_id: moduleId,
+              topic_id: topicId,
             });
             const response = await fetch(
               `/api/bloom/summary/?${params.toString()}`,
@@ -740,7 +749,7 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
 
             if (!response.ok) {
               throw new Error(
-                `Failed to fetch Bloom summary for module ${moduleId}`
+                `Failed to fetch Bloom summary for topic ${topicId} in module ${moduleId}`
               );
             }
 
@@ -748,21 +757,22 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
               bloom_summary?: Record<string, unknown>;
             };
 
-            const summary = payload?.bloom_summary ?? {};
-            Object.entries(summary).forEach(([topicId, rawCounts]) => {
-              const safeCounts = normalizeBloomCounts(rawCounts);
-              const { label, value } = getHighestBloomLevel(safeCounts);
-              combined[String(topicId)] = {
-                label,
-                value,
-                counts: safeCounts,
-              };
-            });
+            const safeCounts = normalizeBloomCounts(payload?.bloom_summary);
+            const { label, value } = getHighestBloomLevel(safeCounts);
+
+            combined[String(topicId)] = {
+              label,
+              value,
+              counts: safeCounts,
+            };
           } catch (error) {
             if (error instanceof DOMException && error.name === "AbortError") {
               return;
             }
-            console.error("Failed to load Bloom summary for thread map", error);
+            console.error(
+              `Failed to load Bloom summary for topic ${topicId} in module ${moduleId}`,
+              error
+            );
           }
         })
       );
@@ -771,7 +781,18 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
         return;
       }
 
-      setTopicBloomLevels(combined);
+      setTopicBloomLevels(() => {
+        const next: Record<string, TopicBloomSummary> = {};
+        topicBloomRequests.forEach(({ topicId }) => {
+          next[String(topicId)] =
+            combined[String(topicId)] ?? {
+              label: null,
+              value: null,
+              counts: null,
+            };
+        });
+        return next;
+      });
     };
 
     fetchSummaries();
@@ -780,7 +801,7 @@ const ThreadMap: React.FC<ThreadMapProps> = ({ module_id }) => {
       isMounted = false;
       controllers.forEach((controller) => controller.abort());
     };
-  }, [bloomModuleIds]);
+  }, [topicBloomRequests]);
 
   useEffect(() => {
     if (interactionMode !== "cursor") {


### PR DESCRIPTION
## Summary
- fetch Bloom taxonomy levels per topic directly from `get_bloom_summary` so topic nodes reflect StudentBloomRecord data
- ensure embedded knowledge capsule popups reset to the top for topics and scroll to the focused concept when applicable

## Testing
- npm run build *(fails: repository missing various type dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc4a61f7dc8332b13a306a249eb016